### PR TITLE
#16 - System / User Channels Test Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mock/general/lib/
 mock/intent-a/lib/
 mock/intent-b/lib/
 mock/intent-c/lib/
+mock/channels/lib/

--- a/mock/channels/index.css
+++ b/mock/channels/index.css
@@ -1,0 +1,15 @@
+html {
+	font-size: 15px;
+	height: 100%;
+}
+
+body {
+	background-color: #f7f7f7;
+	font-size: 14px;
+	font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+	height: 100%;
+}
+
+body {
+	height: 100%;
+} 

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -55,7 +55,7 @@
       window.fdc3.addContextListener(
         "channelsAppContext",
         (context) => {
-          if (context.type === "channelsAppContext" && firedOnce == false) {
+          if (firedOnce == false) {
             firedOnce = true;
             fdc3ApiCalls(context.reverseFunctionCallOrder, context.contextBroadcasts);
           }

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -1,0 +1,65 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <p>Conformance Framework Mock App</p>
+    <p>This app is only used by the conformance framework for test purposes</p>
+    <p></p>
+    <p id="context"></p>
+    <script>
+      let firedOnce = false;
+
+      const fdc3ApiCalls = async (reverseFunctionCallOrder, contextBroadcasts) => {
+        await window.fdc3.leaveCurrentChannel();
+        switch (reverseFunctionCallOrder) {
+          case false:
+            await joinChannel();
+            broadcast(contextBroadcasts);
+            break;
+          case true:
+            await broadcast(contextBroadcasts);
+            joinChannel();
+            break;
+        }
+      }
+
+      //Channels app joins channel 1
+      const joinChannel = async () => {
+        const channels = await window.fdc3.getSystemChannels();
+        if (channels.length > 0) {
+          try {
+            await window.fdc3.joinChannel(channels[0].id);
+          } catch (ex) {
+            throw new Error("Error while calling joinChannel in app B: " + (ex.message ?? ex))
+          }
+        } else {
+          throw new Error("No system channels available for app B");
+        }
+      }
+
+      //Broadcast from channels app
+        const broadcast = async (contextBroadcasts) => {
+          for (const systemBroadcast in contextBroadcasts) {
+            if (contextBroadcasts[systemBroadcast]) {
+              await window.fdc3.broadcast({
+                "type": `fdc3.${systemBroadcast}`
+              });
+            }
+          };
+        }
+
+      //Retrieve context
+      window.fdc3.addContextListener(
+        "channelsAppContext",
+        (context) => {
+          if (context.type === "channelsAppContext" && firedOnce == false) {
+            firedOnce = true;
+            fdc3ApiCalls(context.reverseFunctionCallOrder, context.contextBroadcasts);
+          }
+        });
+    </script>
+  </body>
+</html>

--- a/mock/package.json
+++ b/mock/package.json
@@ -11,7 +11,8 @@
     "start:intent:a": "npx http-server ./intent-a -p 3100",
     "start:intent:b": "npx http-server ./intent-b -p 3101",
     "start:intent:c": "npx http-server ./intent-c -p 3102",
-    "start": "npm-run-all -p start:general start:intent:a start:intent:b start:intent:c"
+    "start:channels": "npx http-server ./channels -p 3103",
+    "start": "npm-run-all -p start:general start:intent:a start:intent:b start:intent:c start:channels"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/tests/app-d-snippet.txt
+++ b/tests/app-d-snippet.txt
@@ -304,3 +304,58 @@
         }
     ]
 },
+"ChannelsApp": {
+	"appId": "ChannelsAppId",
+	"name": "ChannelsApp",
+	"description": "Testing channels app",
+	"manifest": {
+		"window": {
+			"url": "http://localhost:3103",
+			"affinity": "workspaceComponents",
+			"options": {
+				"resizable": true,
+				"autoShow": true,
+				"alwaysOnTop": false,
+				"addToWorkspace": true
+			},
+			"top": "center",
+			"left": "center",
+			"width": 800,
+			"height": 600
+		},
+		"component": {
+			"displayName": "FDC3 Conformance Framework Channels App"
+		},
+		"foreign": {
+			"services": {
+				"windowService": {
+					"allowSnapping": true,
+					"allowGrouping": true,
+					"allowTabbing": true,
+					"allowAutoArrange": true,
+					"allowMinimize": true
+				}
+			},
+			"components": {
+				"App Launcher": {
+					"launchableByUser": true
+				},
+				"Window Manager": {
+					"alwaysOnTopIcon": false,
+					"FSBLHeader": {
+						"hideMaximize": false
+					},
+					"persistWindowState": true,
+					"title": "FDC3 Conformance Framework Channels App"
+				}
+			}
+		}
+	},
+	"version": "1.0.0",
+	"publisher": "Scott Logic",
+	"icons": [
+		{
+			"src": "http://localhost:3000/scott-logic-icon-256.png"
+		}
+	]
+},

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -3,7 +3,7 @@
  */
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
-  TestTimeout: 5000, // Tests that take longer than this (in milliseconds) will fail
+  TestTimeout: 10000, // Tests that take longer than this (in milliseconds) will fail
 } as const;
 
 export default constants;

--- a/tests/src/test/fdc3.addContextListener.ts
+++ b/tests/src/test/fdc3.addContextListener.ts
@@ -1,4 +1,5 @@
 import { Listener } from "@finos/fdc3";
+import { assert, expect } from "chai";
 
 export default () =>
   describe("fdc3.addContextListener", () => {
@@ -13,13 +14,29 @@ export default () =>
 
     it("Method is callable", async () => {
       const contextType = "fdc3.contact";
-      listener = await window.fdc3.addContextListener(
-        contextType,
-        (info: any) => {
-          console.log(
-            `Context listener of type ${contextType} triggered with result ${info}`
-          );
-        }
-      );
+      try {
+        listener = await window.fdc3.addContextListener(
+          contextType,
+          (info: any) => {
+            console.log(
+              `Context listener of type ${contextType} triggered with result ${info}`
+            );
+          }
+        );
+      } catch (ex) {
+        assert.fail("Error while calling method. " + (ex.message ?? ex));
+      }
+    });
+
+    it("Returns listener object", async () => {
+      const contextType = "fdc3.contact";
+
+      try {
+        listener = await window.fdc3.addContextListener(null, () => {});
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
+      } catch (ex) {
+        assert.fail("No listener object returned. " + (ex.message ?? ex));
+      }
     });
   });

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -208,13 +208,8 @@ export default () =>
       //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
       await window.fdc3.open("ChannelsApp", channelsAppContext);
 
-      let wait = new Promise((resolve) => {
-        setTimeout(async function () {
-          resolve(true);
-        }, 3000);
-      });
       //Give listeners time to receive context
-      await wait;
+      await wait();
     });
 
     it("App A adds two context listeners => App A and B join the same channel => App A unsubscribes listeners => App B broadcasts two contexts => App A doesn't receive any context", async () => {
@@ -243,14 +238,9 @@ export default () =>
 
       //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
       window.fdc3.open("ChannelsApp", channelsAppContext);
-      let wait = new Promise((resolve) => {
-        setTimeout(async function () {
-          resolve(true);
-        }, 3000);
-      });
 
       //Give listeners time to receive context
-      await wait;
+      await wait();
     });
 
     it("App A adds two context listeners => App A joins channel 1 then joins channel 2 => App B joins channel 1 then broadcasts two contexts => App A doesn't receive any context", async () => {
@@ -267,14 +257,8 @@ export default () =>
       //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
       await window.fdc3.open("ChannelsApp", channelsAppContext);
 
-      let wait = new Promise((resolve) => {
-        setTimeout(async function () {
-          resolve(true);
-        }, 3000);
-      });
-
       //Give listeners time to receive context
-      await wait;
+      await wait();
     });
 
     it("App A adds two context listeners => App A joins and then leaves channel 1 => App B joins channel 1 and broadcasts two contexts => App A doesn't receive any context", async () => {
@@ -294,14 +278,7 @@ export default () =>
       await window.fdc3.open("ChannelsApp", channelsAppContext);
 
       //Give listeners time to receive context
-      let wait = new Promise((resolve) => {
-        setTimeout(async function () {
-          resolve(true);
-        }, 3000);
-      });
-
-      //Give listeners time to receive context
-      await wait;
+      await wait();
     });
 
     const joinChannel = async (channel: number) => {
@@ -331,4 +308,16 @@ export default () =>
 
       return listenerObject;
     };
+
+    async function wait() {
+      let wait = new Promise((resolve) => {
+        setTimeout(async function () {
+          resolve(true);
+        }, 3000);
+      });
+
+      await wait;
+    }
   });
+
+

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -39,14 +39,13 @@ export default () =>
     });
 
     it("App A adds context listener then joins channel 1 => App B joins channel 1 then broadcasts context => App A receives context from B", async () => {
-      const asyncWrapper = () => {
         return new Promise(async (resolve) => {
           //Add context listener to app A
           listener = await window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
               expect(context.type).to.be.equals("fdc3.instrument");
-              resolve(true);
+              resolve();
             }
           );
 
@@ -59,13 +58,9 @@ export default () =>
           //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts context
           window.fdc3.open("ChannelsApp", channelsAppContext);
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App A joins channel 1 then adds context listener => App B joins channel 1 then broadcasts context => App A receives context", async () => {
-      const asyncWrapper = () => {
         return new Promise(async (resolve) => {
           const channels = await window.fdc3.getSystemChannels();
 
@@ -77,7 +72,7 @@ export default () =>
             "fdc3.instrument",
             (context) => {
               expect(context.type).to.be.equals("fdc3.instrument");
-              resolve(true);
+              resolve();
             }
           );
 
@@ -87,13 +82,9 @@ export default () =>
           //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App B joins channel 1 then broadcasts context => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
-      const asyncWrapper = () => {
         return new Promise(async (resolve) => {
           //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
@@ -106,20 +97,16 @@ export default () =>
             "fdc3.instrument",
             (context) => {
               expect(context.type).to.be.equals("fdc3.instrument");
-              resolve(true);
+              resolve();
             }
           );
 
           assert.isObject(listener);
           expect(typeof listener.unsubscribe).to.be.equals("function");
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App B broadcasts context then joins channel 1 => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
-      const asyncWrapper = () => {
         channelsAppContext.reverseFunctionCallOrder = true;
         return new Promise(async (resolve) => {
           //Open ChannelsApp app. ChannelsApp broadcasts context, then joins channel 1
@@ -133,20 +120,16 @@ export default () =>
             "fdc3.instrument",
             (context) => {
               expect(context.type).to.be.equals("fdc3.instrument");
-              resolve(true);
+              resolve();
             }
           );
 
           assert.isObject(listener);
           expect(typeof listener.unsubscribe).to.be.equals("function");
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App A adds instrument context listener => App A and B join channel 1 => App B broadcasts two contexts => App A receives the instrument context from B", async () => {
-      const asyncWrapper = async () => {
         return new Promise(async (resolve) => {
           channelsAppContext.contextBroadcasts.contact = true;
 
@@ -155,7 +138,7 @@ export default () =>
             "fdc3.instrument",
             (context) => {
               expect(context.type).to.be.equals("fdc3.instrument");
-              resolve(true);
+              resolve();
             }
           );
 
@@ -168,14 +151,10 @@ export default () =>
           //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
           window.fdc3.open("ChannelsApp", channelsAppContext);
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App A adds two context listeners => App A and B join channel 1 => App B broadcasts two contexts => App A receives both contexts from B", async () => {
       let contextsReceived = 0;
-      const asyncWrapper = async () => {
         return new Promise(async (resolve) => {
           channelsAppContext.contextBroadcasts.contact = true;
 
@@ -212,13 +191,10 @@ export default () =>
           function checkIfBothContextsReceived() {
             contextsReceived++;
             if (contextsReceived > 1) {
-              resolve(true);
+              resolve();
             }
           }
         });
-      };
-
-      await asyncWrapper();
     });
 
     it("App A adds two context listeners => App A and B join different channels => App B broadcasts two contexts => App A doesn't receive any context", async () => {

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -39,162 +39,162 @@ export default () =>
     });
 
     it("App A adds context listener then joins channel 1 => App B joins channel 1 then broadcasts context => App A receives context from B", async () => {
-        return new Promise(async (resolve) => {
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              resolve();
-            }
-          );
+      return new Promise(async (resolve) => {
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            resolve();
+          }
+        );
 
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
 
-          //App A joins channel 1
-          await joinChannel(1);
+        //App A joins channel 1
+        await joinChannel(1);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts context
-          window.fdc3.open("ChannelsApp", channelsAppContext);
-        });
+        //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts context
+        window.fdc3.open("ChannelsApp", channelsAppContext);
+      });
     });
 
     it("App A joins channel 1 then adds context listener => App B joins channel 1 then broadcasts context => App A receives context", async () => {
-        return new Promise(async (resolve) => {
-          const channels = await window.fdc3.getSystemChannels();
+      return new Promise(async (resolve) => {
+        const channels = await window.fdc3.getSystemChannels();
 
-          //App A joins channel 1
-          await joinChannel(1);
+        //App A joins channel 1
+        await joinChannel(1);
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              resolve();
-            }
-          );
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            resolve();
+          }
+        );
 
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
 
-          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
-        });
+        //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
+        await window.fdc3.open("ChannelsApp", channelsAppContext);
+      });
     });
 
     it("App B joins channel 1 then broadcasts context => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
-        return new Promise(async (resolve) => {
-          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+      return new Promise(async (resolve) => {
+        //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
+        await window.fdc3.open("ChannelsApp", channelsAppContext);
 
-          //App A joins channel 1
-          await joinChannel(1);
+        //App A joins channel 1
+        await joinChannel(1);
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              resolve();
-            }
-          );
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            resolve();
+          }
+        );
 
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
-        });
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
+      });
     });
 
     it("App B broadcasts context then joins channel 1 => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
-        channelsAppContext.reverseFunctionCallOrder = true;
-        return new Promise(async (resolve) => {
-          //Open ChannelsApp app. ChannelsApp broadcasts context, then joins channel 1
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+      channelsAppContext.reverseFunctionCallOrder = true;
+      return new Promise(async (resolve) => {
+        //Open ChannelsApp app. ChannelsApp broadcasts context, then joins channel 1
+        await window.fdc3.open("ChannelsApp", channelsAppContext);
 
-          //App A joins channel 1
-          await joinChannel(1);
+        //App A joins channel 1
+        await joinChannel(1);
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              resolve();
-            }
-          );
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            resolve();
+          }
+        );
 
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
-        });
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
+      });
     });
 
     it("App A adds instrument context listener => App A and B join channel 1 => App B broadcasts two contexts => App A receives the instrument context from B", async () => {
-        return new Promise(async (resolve) => {
-          channelsAppContext.contextBroadcasts.contact = true;
+      return new Promise(async (resolve) => {
+        channelsAppContext.contextBroadcasts.contact = true;
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              resolve();
-            }
-          );
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            resolve();
+          }
+        );
 
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
 
-          //App A joins channel 1
-          joinChannel(1);
+        //App A joins channel 1
+        joinChannel(1);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          window.fdc3.open("ChannelsApp", channelsAppContext);
-        });
+        //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+        window.fdc3.open("ChannelsApp", channelsAppContext);
+      });
     });
 
     it("App A adds two context listeners => App A and B join channel 1 => App B broadcasts two contexts => App A receives both contexts from B", async () => {
       let contextsReceived = 0;
-        return new Promise(async (resolve) => {
-          channelsAppContext.contextBroadcasts.contact = true;
+      return new Promise(async (resolve) => {
+        channelsAppContext.contextBroadcasts.contact = true;
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(
-            "fdc3.instrument",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.instrument");
-              checkIfBothContextsReceived();
-            }
-          );
-
-          assert.isObject(listener);
-          expect(typeof listener.unsubscribe).to.be.equals("function");
-
-          //Add second context listener to app A
-          listener2 = await window.fdc3.addContextListener(
-            "fdc3.contact",
-            (context) => {
-              expect(context.type).to.be.equals("fdc3.contact");
-              checkIfBothContextsReceived();
-            }
-          );
-
-          assert.isObject(listener2);
-          expect(typeof listener2.unsubscribe).to.be.equals("function");
-
-          //App A joins channel 1
-          await joinChannel(1);
-
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
-
-          function checkIfBothContextsReceived() {
-            contextsReceived++;
-            if (contextsReceived > 1) {
-              resolve();
-            }
+        //Add context listener to app A
+        listener = await window.fdc3.addContextListener(
+          "fdc3.instrument",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.instrument");
+            checkIfBothContextsReceived();
           }
-        });
+        );
+
+        assert.isObject(listener);
+        expect(typeof listener.unsubscribe).to.be.equals("function");
+
+        //Add second context listener to app A
+        listener2 = await window.fdc3.addContextListener(
+          "fdc3.contact",
+          (context) => {
+            expect(context.type).to.be.equals("fdc3.contact");
+            checkIfBothContextsReceived();
+          }
+        );
+
+        assert.isObject(listener2);
+        expect(typeof listener2.unsubscribe).to.be.equals("function");
+
+        //App A joins channel 1
+        await joinChannel(1);
+
+        //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+        await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+        function checkIfBothContextsReceived() {
+          contextsReceived++;
+          if (contextsReceived > 1) {
+            resolve();
+          }
+        }
+      });
     });
 
     it("App A adds two context listeners => App A and B join different channels => App B broadcasts two contexts => App A doesn't receive any context", async () => {

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,9 +1,358 @@
+import { ResolveError, Listener } from "@finos/fdc3";
+import { assert, expect } from "chai";
+
 export default () =>
   describe("fdc3.broadcast", () => {
+    let listener: Listener;
+    let listener2: Listener;
+
+    let channelsAppContext = {
+      type: "channelsAppContext",
+      reverseFunctionCallOrder: false,
+      contextBroadcasts: {
+        instrument: true,
+        contact: false,
+      },
+    };
+
+    afterEach(async () => {
+      if (listener !== undefined) {
+        await listener.unsubscribe();
+        listener = undefined;
+      }
+
+      if (listener2 !== undefined) {
+        await listener2.unsubscribe();
+        listener2 = undefined;
+      }
+
+      await window.fdc3.leaveCurrentChannel();
+      channelsAppContext.reverseFunctionCallOrder = false;
+      channelsAppContext.contextBroadcasts.contact = false;
+    });
+
     it("Method is callable", async () => {
       await window.fdc3.broadcast({
         type: "fdc3.instrument",
         id: { ticker: "AAPL" },
       });
     });
+
+    it("App A adds context listener then joins channel 1 => App B joins channel 1 then broadcasts context => App A receives context from B", async () => {
+      const asyncWrapper = () => {
+        return new Promise(async (resolve) => {
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              resolve(true);
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+
+          //App A joins channel 1
+          await joinChannel(1);
+
+          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts context
+          window.fdc3.open("ChannelsApp", channelsAppContext);
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App A joins channel 1 then adds context listener => App B joins channel 1 then broadcasts context => App A receives context", async () => {
+      const asyncWrapper = () => {
+        return new Promise(async (resolve) => {
+          const channels = await window.fdc3.getSystemChannels();
+
+          //App A joins channel 1
+          await joinChannel(1);
+
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              resolve(true);
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+
+          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
+          await window.fdc3.open("ChannelsApp", channelsAppContext);
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App B joins channel 1 then broadcasts context => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
+      const asyncWrapper = () => {
+        return new Promise(async (resolve) => {
+          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
+          await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+          //App A joins channel 1
+          await joinChannel(1);
+
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              resolve(true);
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App B broadcasts context then joins channel 1 => App A joins channel 1 => App A adds context listener then receives context from B", async () => {
+      const asyncWrapper = () => {
+        channelsAppContext.reverseFunctionCallOrder = true;
+        return new Promise(async (resolve) => {
+          //Open ChannelsApp app. ChannelsApp broadcasts context, then joins channel 1
+          await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+          //App A joins channel 1
+          await joinChannel(1);
+
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              resolve(true);
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App A adds instrument context listener => App A and B join channel 1 => App B broadcasts two contexts => App A receives the instrument context from B", async () => {
+      const asyncWrapper = async () => {
+        return new Promise(async (resolve) => {
+          channelsAppContext.contextBroadcasts.contact = true;
+
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              resolve(true);
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+
+          //App A joins channel 1
+          joinChannel(1);
+
+          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+          window.fdc3.open("ChannelsApp", channelsAppContext);
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App A adds two context listeners => App A and B join channel 1 => App B broadcasts two contexts => App A receives both contexts from B", async () => {
+      let contextsReceived = 0;
+      const asyncWrapper = async () => {
+        return new Promise(async (resolve) => {
+          channelsAppContext.contextBroadcasts.contact = true;
+
+          //Add context listener to app A
+          listener = await window.fdc3.addContextListener(
+            "fdc3.instrument",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.instrument");
+              checkIfBothContextsReceived();
+            }
+          );
+
+          assert.isObject(listener);
+          expect(typeof listener.unsubscribe).to.be.equals("function");
+
+          //Add second context listener to app A
+          listener2 = await window.fdc3.addContextListener(
+            "fdc3.contact",
+            (context) => {
+              expect(context.type).to.be.equals("fdc3.contact");
+              checkIfBothContextsReceived();
+            }
+          );
+
+          assert.isObject(listener2);
+          expect(typeof listener2.unsubscribe).to.be.equals("function");
+
+          //App A joins channel 1
+          await joinChannel(1);
+
+          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+          await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+          function checkIfBothContextsReceived() {
+            contextsReceived++;
+            if (contextsReceived > 1) {
+              resolve(true);
+            }
+          }
+        });
+      };
+
+      await asyncWrapper();
+    });
+
+    it("App A adds two context listeners => App A and B join different channels => App B broadcasts two contexts => App A doesn't receive any context", async () => {
+      channelsAppContext.contextBroadcasts.contact = true;
+
+      //Add two context listeners to app A
+      listener = await addContextListener(listener, "fdc3.instrument");
+      listener2 = await addContextListener(listener2, "fdc3.contact");
+      //App A joins channel 2
+      await joinChannel(2);
+      //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+      await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+      let wait = new Promise((resolve) => {
+        setTimeout(async function () {
+          resolve(true);
+        }, 4000);
+      });
+      //Give listeners time to receive context
+      await wait;
+    });
+
+    it("App A adds two context listeners => App A and B join the same channel => App A unsubscribes listeners => App B broadcasts two contexts => App A doesn't receive any context", async () => {
+      channelsAppContext.contextBroadcasts.contact = true;
+
+      //Add two context listeners
+      listener = await addContextListener(listener, "fdc3.intrument");
+      listener2 = await addContextListener(listener2, "fdc3.contact");
+
+      //App A joins channel 1
+      await joinChannel(1);
+
+      //unsubscribe from listeners
+      if (listener !== undefined) {
+        await listener.unsubscribe();
+        listener = undefined;
+      } else {
+        assert.fail("Listener undefined");
+      }
+      if (listener2 !== undefined) {
+        await listener2.unsubscribe();
+        listener2 = undefined;
+      } else {
+        assert.fail("Listener undefined");
+      }
+
+      //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+      window.fdc3.open("ChannelsApp", channelsAppContext);
+      let wait = new Promise((resolve) => {
+        setTimeout(async function () {
+          resolve(true);
+        }, 4000);
+      });
+
+      //Give listeners time to receive context
+      await wait;
+    });
+
+    it("App A adds two context listeners => App A joins channel 1 then joins channel 2 => App B joins channel 1 then broadcasts two contexts => App A doesn't receive any context", async () => {
+      channelsAppContext.contextBroadcasts.contact = true;
+
+      //Add two context listeners to app A
+      listener = await addContextListener(listener, "fdc3.instrument");
+      listener2 = await addContextListener(listener2, "fdc3.contact");
+
+      //App A joins a channel and then joins another
+      await joinChannel(1);
+      await joinChannel(2);
+
+      //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
+      await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+      let wait = new Promise((resolve) => {
+        setTimeout(async function () {
+          resolve(true);
+        }, 4000);
+      });
+
+      //Give listeners time to receive context
+      await wait;
+    });
+
+    it("App A adds two context listeners => App A joins and then leaves channel 1 => App B joins channel 1 and broadcasts two contexts => App A doesn't receive any context", async () => {
+      channelsAppContext.contextBroadcasts.contact = true;
+
+      //Add two context listeners to app A
+      listener = await addContextListener(listener, "fdc3.instrument");
+      listener2 = await addContextListener(listener2, "fdc3.contact");
+
+      //App A joins channel 1
+      await joinChannel(1);
+
+      //App A leaves channel 1
+      await window.fdc3.leaveCurrentChannel();
+
+      //App B joins channel 1, then broadcasts both contexts
+      await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+      //Give listeners time to receive context
+      let wait = new Promise((resolve) => {
+        setTimeout(async function () {
+          resolve(true);
+        }, 4000);
+      });
+
+      //Give listeners time to receive context
+      await wait;
+    });
+
+    const joinChannel = async (channel: number) => {
+      const channels = await window.fdc3.getSystemChannels();
+      if (channels.length > 0) {
+        await window.fdc3.joinChannel(channels[channel - 1].id);
+      } else {
+        assert.fail("No system channels available for app A");
+      }
+    };
+
+    const addContextListener = async (
+      listenerObject: Listener,
+      contextType: string
+    ) => {
+      listenerObject = await window.fdc3.addContextListener(
+        contextType === null ? null : contextType,
+        (context) => {
+          if (context.type === contextType) {
+            assert.fail(`${contextType} context received`);
+          }
+        }
+      );
+
+      assert.isObject(listenerObject);
+      expect(typeof listenerObject.unsubscribe).to.be.equals("function");
+
+      return listenerObject;
+    };
   });

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -235,7 +235,7 @@ export default () =>
       let wait = new Promise((resolve) => {
         setTimeout(async function () {
           resolve(true);
-        }, 4000);
+        }, 3000);
       });
       //Give listeners time to receive context
       await wait;
@@ -270,7 +270,7 @@ export default () =>
       let wait = new Promise((resolve) => {
         setTimeout(async function () {
           resolve(true);
-        }, 4000);
+        }, 3000);
       });
 
       //Give listeners time to receive context
@@ -294,7 +294,7 @@ export default () =>
       let wait = new Promise((resolve) => {
         setTimeout(async function () {
           resolve(true);
-        }, 4000);
+        }, 3000);
       });
 
       //Give listeners time to receive context
@@ -321,7 +321,7 @@ export default () =>
       let wait = new Promise((resolve) => {
         setTimeout(async function () {
           resolve(true);
-        }, 4000);
+        }, 3000);
       });
 
       //Give listeners time to receive context

--- a/tests/src/test/fdc3.getCurrentChannel.ts
+++ b/tests/src/test/fdc3.getCurrentChannel.ts
@@ -1,6 +1,13 @@
+import { expect } from "chai";
+
 export default () =>
   describe("fdc3.getCurrentChannel", () => {
     it("Method is callable", async () => {
       await window.fdc3.getCurrentChannel();
+    });
+
+    it("getCurrentChannel() returns null if no channel has been joined", async () => {
+      const channel = await window.fdc3.getCurrentChannel();
+      expect(channel).to.be.null;
     });
   });

--- a/tests/src/test/fdc3.joinChannel.ts
+++ b/tests/src/test/fdc3.joinChannel.ts
@@ -1,16 +1,24 @@
+import { assert, expect } from "chai";
+
 export default () =>
   describe("fdc3.joinChannel", () => {
     afterEach(async () => {
       await window.fdc3.leaveCurrentChannel();
     });
 
-    it("Method is callable", async () => {
+    it("Can join channel", async () => {
       const channels = await window.fdc3.getSystemChannels();
 
       if (channels.length > 0) {
-        await window.fdc3.joinChannel(channels[0].id);
+        try {
+          await window.fdc3.joinChannel(channels[0].id);
+          const currentChannel = await window.fdc3.getCurrentChannel();
+          expect(currentChannel).to.not.be.null;
+        } catch (ex) {
+          assert.fail("Error while joining channel: " + (ex.message ?? ex));
+        }
       } else {
-        throw new Error("No system channels are available");
+        assert.fail("No system channels available");
       }
     });
   });


### PR DESCRIPTION
This pull request implements the test cases for "System / User Channels Test Cases" (#16 )

**Notes**
- After having a chat with AJ I decided to scrap the two test cases that target v1.2 and v2.0 respectively. I'm not sure there is a way to pass an invalid Context object to the broadcast() function without casting it to `any`
- Two of the tests fail. The listeners receive context when they shouldn't. I believe the tests are correct but feel free to flag them if you spot anything wrong with them.
