### PR TITLE
Improved error reporting for failed channel tests

### DIFF
--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -4,6 +4,7 @@
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 7000, // Tests that take longer than this (in milliseconds) will fail
+  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
 } as const;
 
 export default constants;

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -3,7 +3,7 @@
  */
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
-  TestTimeout: 8000, // Tests that take longer than this (in milliseconds) will fail
+  TestTimeout: 7000, // Tests that take longer than this (in milliseconds) will fail
 } as const;
 
 export default constants;

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -3,7 +3,7 @@
  */
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
-  TestTimeout: 7000, // Tests that take longer than this (in milliseconds) will fail
+  TestTimeout: 8000, // Tests that take longer than this (in milliseconds) will fail
 } as const;
 
 export default constants;

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,5 +1,6 @@
 import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
 import { assert, expect } from "chai";
+import  constants from "../constants";
 
 const documentation =
   "\r\nDocumentation: https://fdc3.finos.org/docs/api/ref/DesktopAgent\r\nCause:";
@@ -240,22 +241,20 @@ export default () =>
           //Add two context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
 
           listener2 = window.fdc3.addContextListener(
             "fdc3.contact",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener2);
@@ -285,11 +284,10 @@ export default () =>
           //Add context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
@@ -326,11 +324,10 @@ export default () =>
           //Add context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
@@ -354,11 +351,10 @@ export default () =>
           //Add a context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
@@ -645,11 +641,10 @@ export default () =>
           //Add context listener to app A
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
@@ -682,11 +677,10 @@ export default () =>
           //Add context listener to app A
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) => {
+            (context) =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              );
-            }
+              )
           );
 
           validateListenerObject(listener);
@@ -823,7 +817,7 @@ export default () =>
       return new Promise((resolve) =>
         setTimeout(() => {
           resolve(true);
-        }, 3000)
+        }, constants.WaitTime)
       );
     }
 

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -419,11 +419,7 @@ export default () =>
             resolve();
           });
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
+          validateListenerObject(listener);
 
           //App B joins the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
@@ -457,11 +453,7 @@ export default () =>
             resolve();
           });
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
+          validateListenerObject(listener);
 
           //if no context received throw error
           await wait(3000);
@@ -493,11 +485,7 @@ export default () =>
             }
           );
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
+          validateListenerObject(listener);
 
           //App B joins the same app channel as A then broadcasts two contexts
           await window.fdc3.open("ChannelsApp", channelsAppContext);
@@ -530,14 +518,10 @@ export default () =>
             }
           );
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
+          validateListenerObject(listener);
 
           //Add a second context listener to app A
-          listener = await testChannel.addContextListener(
+          listener2 = await testChannel.addContextListener(
             "fdc3.contact",
             (context) => {
               contextTypes.push(context.type);
@@ -545,11 +529,7 @@ export default () =>
             }
           );
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
+          validateListenerObject(listener2);
 
           //App B joins the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
@@ -601,12 +581,6 @@ export default () =>
 
           validateListenerObject(listener);
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
-
           //Unsubscribe from app channel
           listener.unsubscribe();
 
@@ -646,12 +620,6 @@ export default () =>
 
           validateListenerObject(listener);
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
-
           //Unsubscribe from app channel
           listener.unsubscribe();
 
@@ -686,12 +654,6 @@ export default () =>
 
           validateListenerObject(listener);
 
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
-
           //App B joins the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
@@ -702,7 +664,7 @@ export default () =>
       });
 
       it("Should not receive context when joining two different app channels before app B broadcasts the listened type to the first channel that was joined", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A joins another app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the first channel that A joined\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the first channel that A joined\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.joinAppChannel = true;
@@ -728,12 +690,6 @@ export default () =>
           );
 
           validateListenerObject(listener);
-
-          assert.isObject(listener, "No listener object was returned");
-          expect(typeof listener.unsubscribe).to.be.equals(
-            "function",
-            "Listener does not contain an unsubscribe method"
-          );
 
           //App B joins the first channel that A joined then broadcasts context
           window.fdc3.open("ChannelsApp", channelsAppContext);

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,6 +1,6 @@
 import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
 import { assert, expect } from "chai";
-import  constants from "../constants";
+import constants from "../constants";
 
 const documentation =
   "\r\nDocumentation: https://fdc3.finos.org/docs/api/ref/DesktopAgent\r\nCause:";
@@ -312,7 +312,7 @@ export default () =>
       });
 
       it("Should not receive context when joining two different user channels before app B broadcasts the listened type to the first channel that was joined", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A unsubscribes the listener\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.executionComplete = true;

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -61,7 +61,7 @@ export default () =>
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -85,7 +85,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -109,7 +109,7 @@ export default () =>
           validateListenerObject(listener);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -124,7 +124,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //wait for ChannelsApp to run
-          await wait(2000);
+          await wait();
 
           //App A joins channel 1
           await joinChannel(1);
@@ -138,7 +138,7 @@ export default () =>
           validateListenerObject(listener);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -170,7 +170,7 @@ export default () =>
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -224,7 +224,7 @@ export default () =>
           }
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(
             new Error(`${errorMessage} At least one context was not received`)
           );
@@ -267,7 +267,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
-          await wait(3000);
+          await wait();
           resolve();
         });
       });
@@ -373,7 +373,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
-          await wait(3000);
+          await wait();
           resolve();
         });
       });
@@ -425,7 +425,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -440,7 +440,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give app B time to fully execute
-          await wait(3000);
+          await wait();
 
           //App A joins app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
@@ -456,7 +456,7 @@ export default () =>
           validateListenerObject(listener);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -491,7 +491,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -548,7 +548,7 @@ export default () =>
           }
 
           //if no context received throw error
-          await wait(3000);
+          await wait();
           reject(new Error(`${errorMessage} No context received`));
         });
       });
@@ -658,7 +658,7 @@ export default () =>
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
-          await wait(3000);
+          await wait();
           resolve();
         });
       });
@@ -695,7 +695,7 @@ export default () =>
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
-          await wait(3000);
+          await wait();
           resolve();
         });
       });
@@ -819,11 +819,11 @@ export default () =>
       );
     }
 
-    async function wait(milliseconds: number) {
+    async function wait() {
       return new Promise((resolve) =>
         setTimeout(() => {
           resolve(true);
-        }, milliseconds)
+        }, 3000)
       );
     }
 

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -819,11 +819,11 @@ export default () =>
       );
     }
 
-    async function wait(miliseconds: number) {
+    async function wait(milliseconds: number) {
       return new Promise((resolve) =>
         setTimeout(() => {
           resolve(true);
-        }, miliseconds)
+        }, milliseconds)
       );
     }
 


### PR DESCRIPTION
**Improved error reporting for failed channel tests:**
- Added step by step guide on how to reproduce failed broadcast tests
- Added link to documentation in failed tests

Example:
![image](https://user-images.githubusercontent.com/107405201/189939357-7cec90a0-d9ab-4f99-890e-0e7939e6bade.png)

**In addition:**
- Fixed a bug whereby some failed tests were being duplicated
- Fix: some context listeners were using a context type filter when they shouldn't have been
