### PR TITLE
Correcting app channels tests for current context

### DIFF
--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -357,12 +357,12 @@ export default () =>
       });
 
       it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds adds a context listener of type null\r\n- App B joins the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -375,7 +375,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App B joins the same app channel as A then broadcasts context
+          //App B retrieves the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
@@ -384,30 +384,63 @@ export default () =>
         });
       });
 
-      it("Should receive context when app B broadcasts context to an app channel before A joins and listens on the same channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A joins the same app channel as B\r\n- App A adds a context listener of type null${documentation}`;
+      it("Should receive context when app B broadcasts context to an app channel before A retrieves current context", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
 
-          //App B creates/joins an app channel then broadcasts context
+          //App B creates/retrieves an app channel then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give app B time to fully execute
           await wait();
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
-          listener = await testChannel.addContextListener(null, (context) => {
+          //Retrieve current context from channel
+          await testChannel.getCurrentContext().then((context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
           });
 
-          validateListenerObject(listener);
+          //if no context received throw error
+          await wait();
+          reject(new Error(`${errorMessage} No context received`));
+        });
+      });
+
+      it("Should receive context of correct type when app B broadcasts multiple contexts to an app channel before A retrieves current context of a specified type", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
+
+        return new Promise(async (resolve, reject) => {
+          channelsAppContext.useAppChannel = true;
+          channelsAppContext.contextBroadcasts.contact = true;
+
+          //App B creates/retrieves an app channel then broadcasts context
+          await window.fdc3.open("ChannelsApp", channelsAppContext);
+
+          //give app B time to fully execute
+          await wait();
+
+          //App A retrieves app channel
+          const testChannel = await window.fdc3.getOrCreateChannel(
+            "test-channel"
+          );
+
+          //Retrieve current context from channel
+          await testChannel
+            .getCurrentContext("fdc3.instrument")
+            .then((context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+            });
 
           //if no context received throw error
           await wait();
@@ -416,13 +449,13 @@ export default () =>
       });
 
       it("Should only receive the listened context when app B broadcasts multiple contexts to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
           channelsAppContext.contextBroadcasts.contact = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -441,7 +474,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App B joins the same app channel as A then broadcasts two contexts
+          //App B retrieves the same app channel as A then broadcasts two contexts
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //if no context received throw error
@@ -451,14 +484,14 @@ export default () =>
       });
 
       it("Should receive multiple contexts when app B broadcasts the listened types to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           let contextTypes: string[] = [];
           channelsAppContext.useAppChannel = true;
           channelsAppContext.contextBroadcasts.contact = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -485,7 +518,7 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //App B joins the same app channel as A then broadcasts context
+          //App B retrieves the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           function checkIfBothContextsReceived() {
@@ -508,14 +541,14 @@ export default () =>
       });
 
       it("Should not receive context when listening for all context types then unsubscribing an app channel before app B broadcasts to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
           channelsAppContext.contextBroadcasts.contact = true;
           channelsAppContext.broadcastExecutionComplete = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -538,7 +571,7 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //App B joins the same app channel as A then broadcasts context
+          //App B retrieves the same app channel as A then broadcasts context
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           await executionCompleteContext;
@@ -547,14 +580,14 @@ export default () =>
       });
 
       it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
           channelsAppContext.contextBroadcasts.contact = true;
           channelsAppContext.broadcastExecutionComplete = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -577,7 +610,7 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //App B joins the same app channel as A then broadcasts context
+          //App B retrieves the same app channel as A then broadcasts context
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           await executionCompleteContext;
@@ -586,12 +619,12 @@ export default () =>
       });
 
       it("Should not receive context when app B broadcasts context to a different app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -607,7 +640,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App B joins the same app channel as A then broadcasts context
+          //App B retrieves the same app channel as A then broadcasts context
           await window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
@@ -616,18 +649,18 @@ export default () =>
         });
       });
 
-      it("Should not receive context when joining two different app channels before app B broadcasts the listened type to the first channel that was joined", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the first channel that A joined\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+      it("Should not receive context when retrieving two different app channels before app B broadcasts the listened type to the first channel that was retrieved", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the first channel that A retrieved\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           channelsAppContext.useAppChannel = true;
 
-          //App A joins app channel
+          //App A retrieves app channel
           let testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //App A joins different app channel
+          //App A retrieves different app channel
           testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -643,7 +676,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App B joins the first channel that A joined then broadcasts context
+          //App B retrieves the first channel that A retrieved then broadcasts context
           window.fdc3.open("ChannelsApp", channelsAppContext);
 
           //give listener time to receive context
@@ -653,17 +686,17 @@ export default () =>
       });
 
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
         channelsAppContext.useAppChannel = true;
         channelsAppContext.contextBroadcasts.contact = true;
 
-        //App A joins app channel
+        //App A retrieves app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //App B joins the same app channel as A then broadcasts context
+        //App B retrieves the same app channel as A then broadcasts context
         await window.fdc3.open("ChannelsApp", channelsAppContext);
 
         //get contexts from app B
@@ -679,17 +712,17 @@ export default () =>
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts a context with multiple history items to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
 
         channelsAppContext.useAppChannel = true;
         channelsAppContext.broadcastMultipleItems = true;
 
-        //App A joins app channel
+        //App A retrieves app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //App B joins the same app channel as A then broadcasts context
+        //App B retrieves the same app channel as A then broadcasts context
         await window.fdc3.open("ChannelsApp", channelsAppContext);
 
         //Give app B time to execute
@@ -709,7 +742,7 @@ export default () =>
         channelsAppContext.broadcastExecutionComplete = true;
         channelsAppContext.contextBroadcasts.contact = true;
 
-        //App A joins app channel
+        //App A retrieves app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
@@ -720,7 +753,7 @@ export default () =>
           testChannel
         );
 
-        //App B joins the same app channel as A then broadcasts context
+        //App B retrieves the same app channel as A then broadcasts context
         await window.fdc3.open("ChannelsApp", channelsAppContext);
 
         await executionCompleteContext;


### PR DESCRIPTION
An app channel test was relying on the same behavior as user channels in an area where they differ. 

App channels do not auto-broadcast current context to apps that retrieve them and add a context listener. Instead, they have a `getCurrentContext` function which should return either the most recent context or (if a type is specified) the most recent context of that type. This PR replaces teh incorrect test with two tests for the `getCurrentContext` function.

This PR also corrects language used in comments and test output (you don't join app channels, you retrieve them)