### PR TITLE
Refactor channel tests

### DIFF
--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -16,8 +16,8 @@ class Fdc3CommandExecutor {
           this.stats.innerHTML += "joined system channel one/ ";
           break;
         }
-        case commands.retrieveTestChannel: {
-          channel = await this.RetrieveTestChannel();
+        case commands.retrieveTestAppChannel: {
+          channel = await this.RetrieveTestAppChannel();
           this.stats.innerHTML += `retrieved test-channel. Channel = ${JSON.stringify(channel)}/ `;
           break;
         }
@@ -53,7 +53,7 @@ class Fdc3CommandExecutor {
   }
 
   //retrieve/create "test-channel" app channel
-  async RetrieveTestChannel() {
+  async RetrieveTestAppChannel() {
     return await window.fdc3.getOrCreateChannel("test-channel");
   }
 
@@ -129,7 +129,7 @@ const channelType = {
 
 const commands = {
   joinSystemChannelOne: "joinSystemChannelOne",
-  retrieveTestChannel: "retrieveTestChannel",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",
 };

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -1,40 +1,152 @@
-class AppChannelService {
-    async joinChannel() {
-        return await window.fdc3.getOrCreateChannel("test-channel");
+class Fdc3CommandExecutor {
+  stats;
+
+  constructor() {
+    this.stats = window.document.getElementById("context");
+  }
+
+  //execute commands received from app A in order
+  async executeCommands(orderedCommands, config) {
+    let channel;
+    let broadcastService;
+
+    for (let command of orderedCommands) {
+      this.stats.innerHTML += `fdc3.command = ${command}/ `;
+      switch (command) {
+        case commands.joinUserChannelOne: {
+          channel = await this.JoinUserChannelOne();
+          this.stats.innerHTML += `joinUserChannelOne done/ `;
+          break;
+        }
+        case commands.retrieveTestChannel: {
+          channel = await this.RetrieveTestChannel();
+          this.stats.innerHTML += `retrieve test channel done/ `;
+          break;
+        }
+        case commands.broadcastInstrumentContext: {
+          await this.BroadcastContextItem("fdc3.instrument", channel, config);
+          this.stats.innerHTML += `broadcast instrument done/ `;
+          break;
+        }
+        case commands.broadcastContactContext: {
+          await this.BroadcastContextItem("fdc3.contact", channel, config);
+          this.stats.innerHTML += `broadcast contact done/ `;
+          break;
+        }
+        default: {
+          this.stats.innerHTML += `Error - unrecognised command: ${command}/ `;
+        }
+      }
     }
 
-    async broadcast(contextType, historyItem, channel) {
-        await channel.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
-        });
-    }
+    //close AppChannel when test is complete
+    await this.CloseWindowOnCompletion(channel, config.channelType);
+    this.stats.innerHTML += `close app on Completion done/ `;
 
-    async closeAppOnCompletion(contextType, channel) {
-        await channel.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
-    }
-}
+    //notify app A that ChannelsApp has finished executing
+    this.NotifyAppAOnCompletion(config.notifyAppAOnCompletion);
+  }
 
-class UserChannelService {
-    async joinChannel() {
-        const channels = await window.fdc3.getSystemChannels();
-        await window.fdc3.joinChannel(channels[0].id);
-        return channels[0];
-    }
+  async JoinUserChannelOne() {
+    const channels = await window.fdc3.getSystemChannels();
+    await window.fdc3.joinChannel(channels[0].id);
+    return channels[0];
+  }
 
-    async broadcast(contextType, historyItem) {
+  //retrieve/create app channel
+  async RetrieveTestChannel() {
+    return await window.fdc3.getOrCreateChannel("test-channel");
+  }
+
+  //get broadcast service and broadcast the given context item
+  async BroadcastContextItem(contextType, channel, config) {
+    this.stats.innerHTML += `${config.channelType}/ `;
+    let broadcastService = this.getBroadcastService(config.channelType);
+    this.stats.innerHTML += `broadcast service retrieved/ `;
+    await broadcastService.broadcast(contextType, config.historyItems, channel);
+  }
+
+  //get app channel or user channel broadcast service
+  getBroadcastService(currentChannelType) {
+    if (currentChannelType === channelType.user) {
+      this.stats.innerHTML += `returning user channel service/ `;
+      return this.userChannelBroadcastService;
+    } else if (currentChannelType === channelType.app) {
+      this.stats.innerHTML += `returning app channel service/ `;
+      return this.appChannelBroadcastService;
+    } else {
+      this.stats.innerHTML += `Error - unrecognised channel type: ${currentChannelType}/ `;
+    }
+  }
+
+  //app channel broadcast service
+  appChannelBroadcastService = {
+    broadcast: async (contextType, historyItems, channel) => {
+      this.stats.innerHTML += `app channel broadcast func reached/ `;
+      if (channel !== undefined) {
+        for (let i = 0; i < historyItems; i++) {
+          await channel.broadcast({
+            type: contextType,
+            name: `History-item-${i + 1}`,
+          });
+          this.stats.innerHTML += `type: ${contextType}/ name: History-item-${
+            i + 1
+          } broadcast`;
+        }
+      } else {
+        this.stats.innerHTML += "Error - app channel undefined/ ";
+      }
+    },
+  };
+
+  //user channel broadcast service
+  userChannelBroadcastService = {
+    broadcast: async (contextType, historyItems) => {
+      this.stats.innerHTML += `user channel broadcast reached/ `;
+      for (let i = 0; i < historyItems; i++) {
         await window.fdc3.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
+          type: contextType,
+          name: `History-item-${i + 1}`,
         });
-    }
+        this.stats.innerHTML += `type: ${contextType}/ name: History-item-${
+          i + 1
+        } broadcast/ `;
+      }
+    },
+  };
 
-    async closeAppOnCompletion(contextType) {
-        await window.fdc3.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
+  //await instructions from app A to close ChannelsApp on test completion
+  async CloseWindowOnCompletion(channel, channelType) {
+    if (channelType === "user"){
+        await window.fdc3.addContextListener("closeWindow", () =>
+        closeFinsembleWindow()
+      );
+    }else if (channelType === "app"){
+        await channel.addContextListener("closeWindow", () =>
+        closeFinsembleWindow()
+      );
+    }else{
+        this.stats.innerHTML += `Error - unrecognised channel type: ${channelType}/ `;
     }
+  }
+
+  NotifyAppAOnCompletion(notifyAppAOnCompletion) {
+    this.stats.innerHTML += `Notify app on completion = ${notifyAppAOnCompletion}/ `;
+    if (notifyAppAOnCompletion) {
+        this.stats.innerHTML += `Notify app on completion entered/ `;
+      this.BroadcastContextItem("executionComplete", channel, config);
+    }
+  }
 }
 
+const channelType = {
+  user: "user",
+  app: "app",
+};
+
+const commands = {
+  joinUserChannelOne: "joinUserChannelOne",
+  retrieveTestChannel: "retrieveTestChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -10,7 +10,7 @@ class AppChannelService {
         });
     }
 
-    async addContextListener(contextType, channel) {
+    async closeAppOnCompletion(contextType, channel) {
         await channel.addContextListener(
             contextType,
             () => closeFinsembleWindow());
@@ -31,7 +31,7 @@ class UserChannelService {
         });
     }
 
-    async addContextListener(contextType) {
+    async closeAppOnCompletion(contextType) {
         await window.fdc3.addContextListener(
             contextType,
             () => closeFinsembleWindow());

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -18,7 +18,7 @@ class Fdc3CommandExecutor {
         }
         case commands.retrieveTestAppChannel: {
           channel = await this.RetrieveTestAppChannel();
-          this.stats.innerHTML += `retrieved test-channel. Channel = ${JSON.stringify(channel)}/ `;
+          this.stats.innerHTML += `retrieved test app channel/ `;
           break;
         }
         case commands.broadcastInstrumentContext: {
@@ -37,7 +37,7 @@ class Fdc3CommandExecutor {
       }
     }
 
-    //close AppChannel when test is complete
+    //close ChannelsApp when test is complete
     await this.CloseWindowOnCompletion(channel);
 
     //notify app A that ChannelsApp has finished executing

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -22,7 +22,7 @@
         (context) => {
           if (firedOnce === false) {
             firedOnce = true;
-            let commandExecutor = new Fdc3CommandExecutor();
+            const commandExecutor = new Fdc3CommandExecutor();
             commandExecutor.executeCommands(context.commands, context.config);
           }
         });

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -39,7 +39,7 @@
         }
 
         //Add listener so app A can close down Channels app
-        channelService.addContextListener("closeWindow", channel);
+        channelService.closeAppOnCompletion("closeWindow", channel);
         if (context.broadcastExecutionComplete) {
           //broadcast to let App A know Channels app has finished executing
           channelService.broadcast("executionComplete", 1, channel);

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -15,68 +15,15 @@
   <script>
     onFdc3Ready().then(() => {
       let firedOnce = false;
-      const stats = document.getElementById("context");
-      let channelService;
 
-      async function runChannelServices(context) {
-        const channelType = context.useAppChannel ? "app" : "user";
-        channelService = getChannelService(channelType);
-        let channel;
-        switch (context.reverseMethodCallOrder) {
-          //Join channel, then broadcast items
-          case false:
-            channel = await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            await broadcastContextItems(context, channel);
-            break;
-
-          //Broadcast items, then join channel
-          case true:
-            await broadcastContextItems(context);
-            await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            break;
-        }
-
-        //Add listener so app A can close down Channels app
-        channelService.closeAppOnCompletion("closeWindow", channel);
-        if (context.broadcastExecutionComplete) {
-          //broadcast to let App A know Channels app has finished executing
-          channelService.broadcast("executionComplete", 1, channel);
-        }
-      }
-
-      async function broadcastContextItems(context, channel) {
-       const items = context.broadcastMultipleItems ? 2 : 1;
-        for (const contextType in context.contextBroadcasts) {
-          if (context.contextBroadcasts[contextType]) {
-            for (let i = 0; i < items; i++) {
-              const historyItem = i + 1;
-              await channelService.broadcast(`fdc3.${contextType}`, historyItem, channel);
-              stats.innerHTML += `Broadcast fdc3.${contextType} - History-item-${historyItem}/ `;
-            }
-          }
-        };
-      }
-
-      function getChannelService(channelType) {
-        switch (channelType) {
-          case "user":
-            return new UserChannelService();
-          case "app":
-            return new AppChannelService();
-          default:
-            stats.innerHTML += "Unrecognised channel type/ ";
-        }
-      }
-
-      //Retrieve context
+      //await commands from App A, then execute commands
       window.fdc3.addContextListener(
         "channelsAppContext",
         (context) => {
           if (firedOnce === false) {
             firedOnce = true;
-            runChannelServices(context);
+            let commandExecutor = new Fdc3CommandExecutor();
+            commandExecutor.executeCommands(context.commands, context.config);
           }
         });
     });

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -829,13 +829,13 @@ export default () =>
       });
     };
 
-    function buildChannelsAppContext(mockAppCommands : any[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
+    function buildChannelsAppContext(mockAppCommands : Commands[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
         settings: {
-          notifyAppAOnCompletion: notifyAppAOnCompletion || false,
-          broadcastTwoHistoryItems: broadcastTwoHistoryItems || false
+          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
+          broadcastTwoHistoryItems: broadcastTwoHistoryItems ?? false
         }
       };
     } 

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -425,7 +425,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -446,7 +446,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -483,7 +483,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -543,7 +543,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -593,7 +593,7 @@ export default () =>
           validateListenerObject(listener2);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -651,7 +651,7 @@ export default () =>
           listener.unsubscribe();
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -695,7 +695,7 @@ export default () =>
           listener.unsubscribe();
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -732,7 +732,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -774,7 +774,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -799,7 +799,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
           commands.broadcastContactContext,
         ];
@@ -831,7 +831,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
         ];
 
@@ -866,7 +866,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
           commands.broadcastContactContext,
         ];
@@ -986,7 +986,7 @@ export default () =>
 
 const commands = {
   joinSystemChannelOne: "joinSystemChannelOne",
-  retrieveTestChannel: "retrieveTestChannel",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",
 };

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -43,23 +43,15 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -83,23 +75,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -112,23 +96,15 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //App A joins channel 1
@@ -169,24 +145,16 @@ export default () =>
           //App A joins channel 1
           joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -226,24 +194,16 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           function checkIfBothContextsReceived() {
@@ -295,24 +255,16 @@ export default () =>
           //App A joins channel 2
           await joinChannel(2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -351,23 +303,15 @@ export default () =>
             assert.fail("Listener undefined", errorMessage);
           }
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -398,23 +342,15 @@ export default () =>
           await joinChannel(1);
           await joinChannel(2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -443,23 +379,15 @@ export default () =>
           //App A leaves channel 1
           await window.fdc3.leaveCurrentChannel();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -496,23 +424,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -525,23 +445,15 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give app B time to fully execute
@@ -570,24 +482,16 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give app B time to fully execute
@@ -638,24 +542,16 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -696,24 +592,16 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           function checkIfBothContextsReceived() {
@@ -762,24 +650,16 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -787,7 +667,7 @@ export default () =>
         });
       });
 
-      it.only("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
+      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
@@ -814,24 +694,16 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -859,23 +731,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -909,23 +773,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -942,24 +798,16 @@ export default () =>
           "test-channel"
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: false,
-          historyItems: 1,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [
-              commands.retrieveTestChannel,
-              commands.broadcastInstrumentContext,
-              commands.broadcastContactContext,
-            ],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands)
         );
 
         //get contexts from app B
@@ -982,20 +830,15 @@ export default () =>
           "test-channel"
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: true,
-          historyItems: 2,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+        ];
 
         //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [commands.retrieveTestChannel, commands.broadcastInstrumentContext],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands, true, 2)
         );
 
         //Give app B time to execute
@@ -1022,24 +865,16 @@ export default () =>
           testChannel
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: true,
-          historyItems: 1,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [
-              commands.retrieveTestChannel,
-              commands.broadcastInstrumentContext,
-              commands.broadcastContactContext,
-            ],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands, true)
         );
 
         await executionCompleteContext;
@@ -1135,33 +970,22 @@ export default () =>
 
     function buildChannelsAppContext(
       mockAppCommands: string[],
-      channelsAppConfig: IChannelsAppConfig
+      notifyAppAOnCompletion?: boolean,
+      historyItems?: number
     ) {
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
         config: {
-          channelType: channelsAppConfig.channelType,
-          notifyAppAOnCompletion: channelsAppConfig.notifyAppAOnCompletion,
-          historyItems: channelsAppConfig.historyItems,
+          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
+          historyItems: historyItems ?? 1,
         },
       };
     }
   });
 
-interface IChannelsAppConfig {
-  channelType: string;
-  notifyAppAOnCompletion: boolean;
-  historyItems: number;
-}
-
-const channelType = {
-  user: "user",
-  app: "app",
-};
-
 const commands = {
-  joinUserChannelOne: "joinUserChannelOne",
+  joinSystemChannelOne: "joinSystemChannelOne",
   retrieveTestChannel: "retrieveTestChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -409,9 +409,8 @@ export default () =>
 
       it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
-
         return new Promise(async (resolve, reject) => {
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -459,7 +458,7 @@ export default () =>
           //give app B time to fully execute
           await wait();
 
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -497,7 +496,7 @@ export default () =>
           //give app B time to fully execute
           await wait();
 
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -523,7 +522,7 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -793,7 +792,7 @@ export default () =>
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        //App A retrieves app channel
+        //App A retrieves test app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,7 +1,6 @@
 import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
 import { assert, expect } from "chai";
 import constants from "../constants";
-import fdc3AddContextListener from "./fdc3.addContextListener";
 import APIDocumentation from "../apiDocuments";
 
 const documentation =
@@ -44,11 +43,24 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -71,11 +83,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -87,11 +112,24 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //App A joins channel 1
           await joinChannel(1);
@@ -131,12 +169,25 @@ export default () =>
           //App A joins channel 1
           joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -175,12 +226,25 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -231,12 +295,25 @@ export default () =>
           //App A joins channel 2
           await joinChannel(2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -274,11 +351,24 @@ export default () =>
             assert.fail("Listener undefined", errorMessage);
           }
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -308,11 +398,24 @@ export default () =>
           await joinChannel(1);
           await joinChannel(2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -340,11 +443,24 @@ export default () =>
           //App A leaves channel 1
           await window.fdc3.leaveCurrentChannel();
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -380,11 +496,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -396,11 +525,24 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give app B time to fully execute
           await wait();
@@ -428,12 +570,25 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give app B time to fully execute
           await wait();
@@ -483,12 +638,25 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -528,12 +696,25 @@ export default () =>
 
           validateListenerObject(listener2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -581,20 +762,32 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ], true));
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
 
+          //Open ChannelsApp app then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
         });
       });
 
-      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
+      it.only("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
@@ -621,12 +814,25 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -653,11 +859,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -690,11 +909,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -710,12 +942,25 @@ export default () =>
           "test-channel"
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: false,
+          historyItems: 1,
+        };
+
         //Open ChannelsApp app then execute commands in order
-        await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.RetrieveTestChannel,
-          Commands.BroadcastInstrumentContext,
-          Commands.BroadcastContactContext
-        ]));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [
+              commands.retrieveTestChannel,
+              commands.broadcastInstrumentContext,
+              commands.broadcastContactContext,
+            ],
+            channelsAppConfig
+          )
+        );
 
         //get contexts from app B
         const context = await testChannel.getCurrentContext("fdc3.instrument");
@@ -737,11 +982,21 @@ export default () =>
           "test-channel"
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: true,
+          historyItems: 2,
+        };
+
         //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ], false, true));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [commands.retrieveTestChannel, commands.broadcastInstrumentContext],
+            channelsAppConfig
+          )
+        );
 
         //Give app B time to execute
         await wait();
@@ -767,12 +1022,25 @@ export default () =>
           testChannel
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: true,
+          historyItems: 1,
+        };
+
         //Open ChannelsApp app then execute commands in order
-        await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.RetrieveTestChannel,
-          Commands.BroadcastInstrumentContext,
-          Commands.BroadcastContactContext
-        ], true));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [
+              commands.retrieveTestChannel,
+              commands.broadcastInstrumentContext,
+              commands.broadcastContactContext,
+            ],
+            channelsAppConfig
+          )
+        );
 
         await executionCompleteContext;
 
@@ -865,21 +1133,36 @@ export default () =>
       });
     };
 
-    function buildChannelsAppContext(mockAppCommands : Commands[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
+    function buildChannelsAppContext(
+      mockAppCommands: string[],
+      channelsAppConfig: IChannelsAppConfig
+    ) {
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
-        settings: {
-          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
-          broadcastTwoHistoryItems: broadcastTwoHistoryItems ?? false
-        }
+        config: {
+          channelType: channelsAppConfig.channelType,
+          notifyAppAOnCompletion: channelsAppConfig.notifyAppAOnCompletion,
+          historyItems: channelsAppConfig.historyItems,
+        },
       };
-    } 
-
-    enum Commands {
-      JoinUserChannelOne,
-      RetrieveTestChannel,
-      BroadcastInstrumentContext,
-      BroadcastContactContext,
     }
   });
+
+interface IChannelsAppConfig {
+  channelType: string;
+  notifyAppAOnCompletion: boolean;
+  historyItems: number;
+}
+
+const channelType = {
+  user: "user",
+  app: "app",
+};
+
+const commands = {
+  joinUserChannelOne: "joinUserChannelOne",
+  retrieveTestChannel: "retrieveTestChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -364,10 +364,10 @@ export default () =>
       });
 
       it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds adds a context listener of type null\r\n- App B joins the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -382,7 +382,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -392,31 +392,67 @@ export default () =>
         });
       });
 
-      it("Should receive context when app B broadcasts context to an app channel before A joins and listens on the same channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A joins the same app channel as B\r\n- App A adds a context listener of type null${documentation}`;
+      it("Should receive context when app B broadcasts context to an app channel before A retrieves current context", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
           //give app B time to fully execute
           await wait();
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
-          listener = await testChannel.addContextListener(null, (context) => {
+          //Retrieve current context from channel
+          await testChannel.getCurrentContext().then((context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
           });
 
           validateListenerObject(listener);
+
+          //if no context received throw error
+          await wait();
+          reject(new Error(`${errorMessage} No context received`));
+        });
+      });
+
+      it("Should receive context of correct type when app B broadcasts multiple contexts to an app channel before A retrieves current context of a specified type", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
+
+        return new Promise(async (resolve, reject) => {
+          //Open ChannelsApp app then execute commands in order
+          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
+            Commands.RetrieveTestChannel,
+            Commands.BroadcastInstrumentContext,
+            Commands.BroadcastContactContext
+          ]));
+
+          //give app B time to fully execute
+          await wait();
+
+          //App A retrieves app channel
+          const testChannel = await window.fdc3.getOrCreateChannel(
+            "test-channel"
+          );
+
+          //Retrieve current context from channel
+          await testChannel
+            .getCurrentContext("fdc3.instrument")
+            .then((context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+            });
 
           //if no context received throw error
           await wait();
@@ -425,10 +461,10 @@ export default () =>
       });
 
       it("Should only receive the listened context when app B broadcasts multiple contexts to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -449,7 +485,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ]));
@@ -461,11 +497,11 @@ export default () =>
       });
 
       it("Should receive multiple contexts when app B broadcasts the listened types to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           let contextTypes: string[] = [];
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -494,7 +530,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ]));
@@ -519,10 +555,10 @@ export default () =>
       });
 
       it("Should not receive context when listening for all context types then unsubscribing an app channel before app B broadcasts to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -547,7 +583,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ], true));
@@ -559,10 +595,10 @@ export default () =>
       });
 
       it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -587,7 +623,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ], true));
@@ -598,10 +634,10 @@ export default () =>
       });
 
       it("Should not receive context when app B broadcasts context to a different app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -619,7 +655,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -629,16 +665,16 @@ export default () =>
         });
       });
 
-      it("Should not receive context when joining two different app channels before app B broadcasts the listened type to the first channel that was joined", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the first channel that A joined\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+      it("Should not receive context when retrieving two different app channels before app B broadcasts the listened type to the first channel that was retrieved", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the first channel that A retrieved\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           let testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //App A joins different app channel
+          //App A retrieves a different app channel
           testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -656,7 +692,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -667,16 +703,16 @@ export default () =>
       });
 
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.JoinTestChannel,
+          Commands.RetrieveTestChannel,
           Commands.BroadcastInstrumentContext,
           Commands.BroadcastContactContext
         ]));
@@ -694,16 +730,16 @@ export default () =>
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts a context with multiple history items to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //Open ChannelsApp app, join test channel then broadcast two different intrument contexts
+        //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ], false, true));
 
@@ -718,9 +754,9 @@ export default () =>
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts two different contexts to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
@@ -733,7 +769,7 @@ export default () =>
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.JoinTestChannel,
+          Commands.RetrieveTestChannel,
           Commands.BroadcastInstrumentContext,
           Commands.BroadcastContactContext
         ], true));
@@ -842,7 +878,7 @@ export default () =>
 
     enum Commands {
       JoinUserChannelOne,
-      JoinTestChannel,
+      RetrieveTestChannel,
       BroadcastInstrumentContext,
       BroadcastContactContext,
     }

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -1,6 +1,8 @@
 import { OpenError, Context } from "@finos/fdc3";
+import { resolveObjectURL } from "buffer";
 import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
+import constants from "../constants";
 
 const appBName = "MockApp";
 const appBId = "MockAppId";
@@ -8,7 +10,7 @@ const appBId = "MockAppId";
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
 const createReceiver = (contextType: string) => {
-  const messageReceived = new Promise<Context>(async (resolve) => {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
     await window.fdc3.getOrCreateChannel("FDC3-Conformance-Channel");
     await window.fdc3.joinChannel("FDC3-Conformance-Channel");
 
@@ -19,10 +21,22 @@ const createReceiver = (contextType: string) => {
         listener.unsubscribe();
       }
     );
+
+    //reject promise if no context received
+    await wait();
+    reject(new Error("No context received from app B"));
   });
 
   return messageReceived;
 };
+
+async function wait() {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime)
+  );
+}
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation.open + "\r\nCause";
 


### PR DESCRIPTION
This pull request aims to make channel tests easier to read and follow.
An array of commands is sent to the ChannelsApp and the ChannelsApp executes these commands in order.

Running the ChannelsApp logic within a Typescript file would have required invoking the typescript functionality from a javascript file. As a result, I stuck with using a single JS file for the sake of simplicity.

Changes to Intent/Open tests:
- When running `createReceiver`, If no context is received, the promise now gets rejected with an error message instead of timing out.