### PR TITLE
Channel tests refactor & improved test efficiency

### DIFF
--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -16,8 +16,8 @@ class Fdc3CommandExecutor {
           this.stats.innerHTML += "joined system channel one/ ";
           break;
         }
-        case commands.retrieveTestChannel: {
-          channel = await this.RetrieveTestChannel();
+        case commands.retrieveTestAppChannel: {
+          channel = await this.RetrieveTestAppChannel();
           this.stats.innerHTML += `retrieved test-channel. Channel = ${JSON.stringify(channel)}/ `;
           break;
         }
@@ -53,7 +53,7 @@ class Fdc3CommandExecutor {
   }
 
   //retrieve/create "test-channel" app channel
-  async RetrieveTestChannel() {
+  async RetrieveTestAppChannel() {
     return await window.fdc3.getOrCreateChannel("test-channel");
   }
 
@@ -129,7 +129,7 @@ const channelType = {
 
 const commands = {
   joinSystemChannelOne: "joinSystemChannelOne",
-  retrieveTestChannel: "retrieveTestChannel",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",
 };

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -108,11 +108,7 @@ class Fdc3CommandExecutor {
     const appControlChannel = await window.fdc3.getOrCreateChannel(
       "app-control"
     );
-    await this.broadcastContextItem(
-      "executionComplete",
-      appControlChannel,
-      1
-    );
+    await this.broadcastContextItem("executionComplete", appControlChannel, 1);
   }
 
   async NotifyAppAOnWindowClose() {

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -1,40 +1,152 @@
-class AppChannelService {
-    async joinChannel() {
-        return await window.fdc3.getOrCreateChannel("test-channel");
+class Fdc3CommandExecutor {
+  stats;
+
+  constructor() {
+    this.stats = window.document.getElementById("context");
+  }
+
+  //execute commands received from app A in order
+  async executeCommands(orderedCommands, config) {
+    let channel;
+    let broadcastService;
+
+    for (let command of orderedCommands) {
+      this.stats.innerHTML += `fdc3.command = ${command}/ `;
+      switch (command) {
+        case commands.joinUserChannelOne: {
+          channel = await this.JoinUserChannelOne();
+          this.stats.innerHTML += `joinUserChannelOne done/ `;
+          break;
+        }
+        case commands.retrieveTestChannel: {
+          channel = await this.RetrieveTestChannel();
+          this.stats.innerHTML += `retrieve test channel done/ `;
+          break;
+        }
+        case commands.broadcastInstrumentContext: {
+          await this.BroadcastContextItem("fdc3.instrument", channel, config);
+          this.stats.innerHTML += `broadcast instrument done/ `;
+          break;
+        }
+        case commands.broadcastContactContext: {
+          await this.BroadcastContextItem("fdc3.contact", channel, config);
+          this.stats.innerHTML += `broadcast contact done/ `;
+          break;
+        }
+        default: {
+          this.stats.innerHTML += `Error - unrecognised command: ${command}/ `;
+        }
+      }
     }
 
-    async broadcast(contextType, historyItem, channel) {
-        await channel.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
-        });
-    }
+    //close AppChannel when test is complete
+    await this.CloseWindowOnCompletion(channel, config.channelType);
+    this.stats.innerHTML += `close app on Completion done/ `;
 
-    async closeAppOnCompletion(contextType, channel) {
-        await channel.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
-    }
-}
+    //notify app A that ChannelsApp has finished executing
+    this.NotifyAppAOnCompletion(config.notifyAppAOnCompletion);
+  }
 
-class UserChannelService {
-    async joinChannel() {
-        const channels = await window.fdc3.getSystemChannels();
-        await window.fdc3.joinChannel(channels[0].id);
-        return channels[0];
-    }
+  async JoinUserChannelOne() {
+    const channels = await window.fdc3.getSystemChannels();
+    await window.fdc3.joinChannel(channels[0].id);
+    return channels[0];
+  }
 
-    async broadcast(contextType, historyItem) {
+  //retrieve/create app channel
+  async RetrieveTestChannel() {
+    return await window.fdc3.getOrCreateChannel("test-channel");
+  }
+
+  //get broadcast service and broadcast the given context item
+  async BroadcastContextItem(contextType, channel, config) {
+    this.stats.innerHTML += `${config.channelType}/ `;
+    let broadcastService = this.getBroadcastService(config.channelType);
+    this.stats.innerHTML += `broadcast service retrieved/ `;
+    await broadcastService.broadcast(contextType, config.historyItems, channel);
+  }
+
+  //get app channel or user channel broadcast service
+  getBroadcastService(currentChannelType) {
+    if (currentChannelType === channelType.user) {
+      this.stats.innerHTML += `returning user channel service/ `;
+      return this.userChannelBroadcastService;
+    } else if (currentChannelType === channelType.app) {
+      this.stats.innerHTML += `returning app channel service/ `;
+      return this.appChannelBroadcastService;
+    } else {
+      this.stats.innerHTML += `Error - unrecognised channel type: ${currentChannelType}/ `;
+    }
+  }
+
+  //app channel broadcast service
+  appChannelBroadcastService = {
+    broadcast: async (contextType, historyItems, channel) => {
+      this.stats.innerHTML += `app channel broadcast func reached/ `;
+      if (channel !== undefined) {
+        for (let i = 0; i < historyItems; i++) {
+          await channel.broadcast({
+            type: contextType,
+            name: `History-item-${i + 1}`,
+          });
+          this.stats.innerHTML += `type: ${contextType}/ name: History-item-${
+            i + 1
+          } broadcast`;
+        }
+      } else {
+        this.stats.innerHTML += "Error - app channel undefined/ ";
+      }
+    },
+  };
+
+  //user channel broadcast service
+  userChannelBroadcastService = {
+    broadcast: async (contextType, historyItems) => {
+      this.stats.innerHTML += `user channel broadcast reached/ `;
+      for (let i = 0; i < historyItems; i++) {
         await window.fdc3.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
+          type: contextType,
+          name: `History-item-${i + 1}`,
         });
-    }
+        this.stats.innerHTML += `type: ${contextType}/ name: History-item-${
+          i + 1
+        } broadcast/ `;
+      }
+    },
+  };
 
-    async closeAppOnCompletion(contextType) {
-        await window.fdc3.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
+  //await instructions from app A to close ChannelsApp on test completion
+  async CloseWindowOnCompletion(channel, channelType) {
+    if (channelType === "user"){
+        await window.fdc3.addContextListener("closeWindow", () =>
+        closeFinsembleWindow()
+      );
+    }else if (channelType === "app"){
+        await channel.addContextListener("closeWindow", () =>
+        closeFinsembleWindow()
+      );
+    }else{
+        this.stats.innerHTML += `Error - unrecognised channel type: ${channelType}/ `;
     }
+  }
+
+  NotifyAppAOnCompletion(notifyAppAOnCompletion) {
+    this.stats.innerHTML += `Notify app on completion = ${notifyAppAOnCompletion}/ `;
+    if (notifyAppAOnCompletion) {
+        this.stats.innerHTML += `Notify app on completion entered/ `;
+      this.BroadcastContextItem("executionComplete", channel, config);
+    }
+  }
 }
 
+const channelType = {
+  user: "user",
+  app: "app",
+};
+
+const commands = {
+  joinUserChannelOne: "joinUserChannelOne",
+  retrieveTestChannel: "retrieveTestChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -33,11 +33,11 @@ class Fdc3CommandExecutor {
     }
 
     //close ChannelsApp when test is complete
-    await this.closeWindowOnCompletion(channel, config);
+    await this.closeWindowOnCompletion();
 
     //notify app A that ChannelsApp has finished executing
     if (config.notifyAppAOnCompletion) {
-      await this.notifyAppAOnCompletion(channel, config);
+      await this.notifyAppAOnCompletion();
     }
   }
 
@@ -94,34 +94,32 @@ class Fdc3CommandExecutor {
   };
 
   //close ChannelsApp on completion and respond to app A
-  async closeWindowOnCompletion(channel, config) {
-    if (channel.type === channelType.system) {
-      await window.fdc3.addContextListener("closeWindow", async () => {
-        window.close();
-        await window.fdc3.broadcast({type: "windowClosed"});
-      });
-    } else if (channel.type === channelType.app) {
-      await channel.addContextListener("closeWindow", async () => {
-        window.close();
-        channel.broadcast({type: "windowClosed"});
-      });
-    }
+  async closeWindowOnCompletion() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    await appControlChannel.addContextListener("closeWindow", async () => {
+      window.close();
+      appControlChannel.broadcast({ type: "windowClosed" });
+    });
   }
 
-  async notifyAppAOnCompletion(channel, config) {
+  async notifyAppAOnCompletion() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
     await this.broadcastContextItem(
       "executionComplete",
-      channel,
-      config.historyItems
+      appControlChannel,
+      1
     );
   }
 
-  async NotifyAppAOnWindowClose(channel, config) {
-    await this.broadcastContextItem(
-      "windowClosed",
-      channel,
-      config.historyItems
+  async NotifyAppAOnWindowClose() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
     );
+    await this.broadcastContextItem("windowClosed", appControlChannel, 1);
   }
 }
 

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -12,17 +12,17 @@ class Fdc3CommandExecutor {
     for (let command of orderedCommands) {
       switch (command) {
         case commands.joinSystemChannelOne: {
-          channel = await this.JoinSystemChannelOne();
+          channel = await this.joinSystemChannelOne();
           this.stats.innerHTML += "joined system channel one/ ";
           break;
         }
         case commands.retrieveTestAppChannel: {
-          channel = await this.RetrieveTestAppChannel();
+          channel = await this.retrieveTestAppChannel();
           this.stats.innerHTML += `retrieved test app channel/ `;
           break;
         }
         case commands.broadcastInstrumentContext: {
-          await this.BroadcastContextItem(
+          await this.broadcastContextItem(
             "fdc3.instrument",
             channel,
             config.historyItems
@@ -31,7 +31,7 @@ class Fdc3CommandExecutor {
           break;
         }
         case commands.broadcastContactContext: {
-          await this.BroadcastContextItem(
+          await this.broadcastContextItem(
             "fdc3.contact",
             channel,
             config.historyItems
@@ -46,27 +46,27 @@ class Fdc3CommandExecutor {
     }
 
     //close ChannelsApp when test is complete
-    await this.CloseWindowOnCompletion(channel, config);
+    await this.closeWindowOnCompletion(channel, config);
 
     //notify app A that ChannelsApp has finished executing
     if (config.notifyAppAOnCompletion) {
-      await this.NotifyAppAOnCompletion(channel, config);
+      await this.notifyAppAOnCompletion(channel, config);
     }
   }
 
-  async JoinSystemChannelOne() {
+  async joinSystemChannelOne() {
     const channels = await window.fdc3.getSystemChannels();
     await window.fdc3.joinChannel(channels[0].id);
     return channels[0];
   }
 
   //retrieve/create "test-channel" app channel
-  async RetrieveTestAppChannel() {
+  async retrieveTestAppChannel() {
     return await window.fdc3.getOrCreateChannel("test-channel");
   }
 
   //get broadcast service and broadcast the given context type
-  async BroadcastContextItem(contextType, channel, historyItems) {
+  async broadcastContextItem(contextType, channel, historyItems) {
     let broadcastService = this.getBroadcastService(channel.type);
     await broadcastService.broadcast(contextType, historyItems, channel);
   }
@@ -111,52 +111,36 @@ class Fdc3CommandExecutor {
   };
 
   //close ChannelsApp on completion and respond to app A
-  async CloseWindowOnCompletion(channel, config) {
+  async closeWindowOnCompletion(channel, config) {
     if (channel.type === channelType.system) {
       await window.fdc3.addContextListener("closeWindow", async () => {
         window.close();
         await window.fdc3.broadcast({type: "windowClosed"});
       });
     } else if (channel.type === channelType.app) {
-      this.stats.innerHTML += "app channel chosen/ ";
       await channel.addContextListener("closeWindow", async () => {
-        this.stats.innerHTML += "close window on completion reached/ ";
         window.close();
         channel.broadcast({type: "windowClosed"});
-        this.stats.innerHTML += "window closed/ ";
       });
     } else {
       this.stats.innerHTML += `Error - unrecognised channel type: ${channel.type}/ `;
     }
   }
 
-  async NotifyAppAOnCompletion(channel, config) {
-    this.stats.innerHTML += "NotifyAppAOnCompletion/ ";
-    await this.BroadcastContextItem(
+  async notifyAppAOnCompletion(channel, config) {
+    await this.broadcastContextItem(
       "executionComplete",
       channel,
       config.historyItems
     );
-    this.stats.innerHTML += "NotifyAppAOnCompletion done/ ";
   }
 
   async NotifyAppAOnWindowClose(channel, config) {
-    this.stats.innerHTML += "NotifyAppAOnWindowClose/ ";
-    await this.BroadcastContextItem(
+    await this.broadcastContextItem(
       "windowClosed",
       channel,
       config.historyItems
     );
-
-    this.stats.innerHTML += "NotifyAppAOnWindowClose done/ ";
-  }
-
-  async wait() {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(true);
-      }, 3000);
-    });
   }
 }
 

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -10,7 +10,7 @@ class AppChannelService {
         });
     }
 
-    async addContextListener(contextType, channel) {
+    async closeAppOnCompletion(contextType, channel) {
         await channel.addContextListener(
             contextType,
             () => closeFinsembleWindow());
@@ -31,7 +31,7 @@ class UserChannelService {
         });
     }
 
-    async addContextListener(contextType) {
+    async closeAppOnCompletion(contextType) {
         await window.fdc3.addContextListener(
             contextType,
             () => closeFinsembleWindow());

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -18,7 +18,7 @@ class Fdc3CommandExecutor {
         }
         case commands.retrieveTestAppChannel: {
           channel = await this.RetrieveTestAppChannel();
-          this.stats.innerHTML += `retrieved test-channel. Channel = ${JSON.stringify(channel)}/ `;
+          this.stats.innerHTML += `retrieved test app channel/ `;
           break;
         }
         case commands.broadcastInstrumentContext: {
@@ -37,7 +37,7 @@ class Fdc3CommandExecutor {
       }
     }
 
-    //close AppChannel when test is complete
+    //close ChannelsApp when test is complete
     await this.CloseWindowOnCompletion(channel);
 
     //notify app A that ChannelsApp has finished executing

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -106,21 +106,16 @@ class Fdc3CommandExecutor {
           type: contextType,
           name: `History-item-${i + 1}`,
         });
-        this.stats.innerHTML += "broadcasr happened/ ";
       }
-      this.stats.innerHTML += "broadcasr end/ ";
     },
   };
 
-  //await instructions from app A to close ChannelsApp on test completion
+  //close ChannelsApp on completion and respond to app A
   async CloseWindowOnCompletion(channel, config) {
-    this.stats.innerHTML += "closewindowoncompletion/ ";
     if (channel.type === channelType.system) {
-      this.stats.innerHTML += "system channel chosen/ ";
       await window.fdc3.addContextListener("closeWindow", async () => {
         window.close();
         await window.fdc3.broadcast({type: "windowClosed"});
-        //await this.NotifyAppAOnWindowClose(channel, config);
       });
     } else if (channel.type === channelType.app) {
       this.stats.innerHTML += "app channel chosen/ ";
@@ -136,19 +131,24 @@ class Fdc3CommandExecutor {
   }
 
   async NotifyAppAOnCompletion(channel, config) {
+    this.stats.innerHTML += "NotifyAppAOnCompletion/ ";
     await this.BroadcastContextItem(
       "executionComplete",
       channel,
       config.historyItems
     );
+    this.stats.innerHTML += "NotifyAppAOnCompletion done/ ";
   }
 
   async NotifyAppAOnWindowClose(channel, config) {
+    this.stats.innerHTML += "NotifyAppAOnWindowClose/ ";
     await this.BroadcastContextItem(
       "windowClosed",
       channel,
       config.historyItems
     );
+
+    this.stats.innerHTML += "NotifyAppAOnWindowClose done/ ";
   }
 
   async wait() {

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -9,7 +9,7 @@ class Fdc3CommandExecutor {
   async executeCommands(orderedCommands, config) {
     let channel;
 
-    for (let command of orderedCommands) {
+    for (const command of orderedCommands) {
       switch (command) {
         case commands.joinSystemChannelOne: {
           channel = await this.joinSystemChannelOne();

--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -1,10 +1,4 @@
 class Fdc3CommandExecutor {
-  stats;
-
-  constructor() {
-    this.stats = window.document.getElementById("context");
-  }
-
   //execute commands in order
   async executeCommands(orderedCommands, config) {
     let channel;
@@ -13,12 +7,10 @@ class Fdc3CommandExecutor {
       switch (command) {
         case commands.joinSystemChannelOne: {
           channel = await this.joinSystemChannelOne();
-          this.stats.innerHTML += "joined system channel one/ ";
           break;
         }
         case commands.retrieveTestAppChannel: {
           channel = await this.retrieveTestAppChannel();
-          this.stats.innerHTML += `retrieved test app channel/ `;
           break;
         }
         case commands.broadcastInstrumentContext: {
@@ -27,7 +19,6 @@ class Fdc3CommandExecutor {
             channel,
             config.historyItems
           );
-          this.stats.innerHTML += "fdc3.instrument type broadcast/ ";
           break;
         }
         case commands.broadcastContactContext: {
@@ -36,11 +27,7 @@ class Fdc3CommandExecutor {
             channel,
             config.historyItems
           );
-          this.stats.innerHTML += "fdc3.contact type broadcast/ ";
           break;
-        }
-        default: {
-          this.stats.innerHTML += `Error - unrecognised command: ${command}/ `;
         }
       }
     }
@@ -77,8 +64,6 @@ class Fdc3CommandExecutor {
       return this.systemChannelBroadcastService;
     } else if (currentChannelType === channelType.app) {
       return this.appChannelBroadcastService;
-    } else {
-      this.stats.innerHTML += `Error - unrecognised channel type: ${currentChannelType}/ `;
     }
   }
 
@@ -92,8 +77,6 @@ class Fdc3CommandExecutor {
             name: `History-item-${i + 1}`,
           });
         }
-      } else {
-        this.stats.innerHTML += "Error - app channel undefined/ ";
       }
     },
   };
@@ -122,8 +105,6 @@ class Fdc3CommandExecutor {
         window.close();
         channel.broadcast({type: "windowClosed"});
       });
-    } else {
-      this.stats.innerHTML += `Error - unrecognised channel type: ${channel.type}/ `;
     }
   }
 

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -22,7 +22,7 @@
         (context) => {
           if (firedOnce === false) {
             firedOnce = true;
-            let commandExecutor = new Fdc3CommandExecutor();
+            const commandExecutor = new Fdc3CommandExecutor();
             commandExecutor.executeCommands(context.commands, context.config);
           }
         });

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -39,7 +39,7 @@
         }
 
         //Add listener so app A can close down Channels app
-        channelService.addContextListener("closeWindow", channel);
+        channelService.closeAppOnCompletion("closeWindow", channel);
         if (context.broadcastExecutionComplete) {
           //broadcast to let App A know Channels app has finished executing
           channelService.broadcast("executionComplete", 1, channel);

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -15,68 +15,15 @@
   <script>
     onFdc3Ready().then(() => {
       let firedOnce = false;
-      const stats = document.getElementById("context");
-      let channelService;
 
-      async function runChannelServices(context) {
-        const channelType = context.useAppChannel ? "app" : "user";
-        channelService = getChannelService(channelType);
-        let channel;
-        switch (context.reverseMethodCallOrder) {
-          //Join channel, then broadcast items
-          case false:
-            channel = await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            await broadcastContextItems(context, channel);
-            break;
-
-          //Broadcast items, then join channel
-          case true:
-            await broadcastContextItems(context);
-            await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            break;
-        }
-
-        //Add listener so app A can close down Channels app
-        channelService.closeAppOnCompletion("closeWindow", channel);
-        if (context.broadcastExecutionComplete) {
-          //broadcast to let App A know Channels app has finished executing
-          channelService.broadcast("executionComplete", 1, channel);
-        }
-      }
-
-      async function broadcastContextItems(context, channel) {
-       const items = context.broadcastMultipleItems ? 2 : 1;
-        for (const contextType in context.contextBroadcasts) {
-          if (context.contextBroadcasts[contextType]) {
-            for (let i = 0; i < items; i++) {
-              const historyItem = i + 1;
-              await channelService.broadcast(`fdc3.${contextType}`, historyItem, channel);
-              stats.innerHTML += `Broadcast fdc3.${contextType} - History-item-${historyItem}/ `;
-            }
-          }
-        };
-      }
-
-      function getChannelService(channelType) {
-        switch (channelType) {
-          case "user":
-            return new UserChannelService();
-          case "app":
-            return new AppChannelService();
-          default:
-            stats.innerHTML += "Unrecognised channel type/ ";
-        }
-      }
-
-      //Retrieve context
+      //await commands from App A, then execute commands
       window.fdc3.addContextListener(
         "channelsAppContext",
         (context) => {
           if (firedOnce === false) {
             firedOnce = true;
-            runChannelServices(context);
+            let commandExecutor = new Fdc3CommandExecutor();
+            commandExecutor.executeCommands(context.commands, context.config);
           }
         });
     });

--- a/mock/general/index.html
+++ b/mock/general/index.html
@@ -1,39 +1,38 @@
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="index.css" />
-  </head>
-  <body>
-    <p>Conformance Framework Mock App</p>
-    <p>This app is only used by the conformance framework for test purposes.</p>
-    <p></p>
-    <p id="context"></p>
-    <script src="lib/mock-functions.js"></script>
-    <script>
-      onFdc3Ready().then(() => {
-        const stats = document.getElementById("context");
-  
-        window.fdc3.joinChannel("FDC3-Conformance-Channel").then(() => {
-          // broadcast that this app has opened
-          window.fdc3.broadcast({
-            type: "fdc3-conformance-opened",
-          });
-  
-          // Context listeners used by tests.
-          window.fdc3.addContextListener("fdc3.testReceiver", (context) => {
-            stats.innerHTML = `Received Data: ${JSON.stringify(context)}`;
-  
-            // broadcast that this app has received context
-            window.fdc3.broadcast({
-              type: "fdc3-conformance-context-received",
-              context: context,
-            });
-          });
-  
-          window.fdc3.addContextListener("fdc3.instrument");
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="index.css" />
+</head>
+
+<body>
+  <p>Conformance Framework Mock App</p>
+  <p>This app is only used by the conformance framework for test purposes.</p>
+  <p></p>
+  <script src="lib/mock-functions.js"></script>
+  <script type="module">
+    onFdc3Ready().then(() => {
+      window.fdc3.joinChannel("FDC3-Conformance-Channel").then(() => {
+        // broadcast that this app has opened
+        window.fdc3.broadcast({
+          type: "fdc3-conformance-opened",
         });
-        setupCloseListener(window.fdc3);
+
+        // Context listeners used by tests.
+        window.fdc3.addContextListener("fdc3.testReceiver", (context) => {
+
+          // broadcast that this app has received context
+          window.fdc3.broadcast({
+            type: "fdc3-conformance-context-received",
+            context: context,
+          });
+        });
+
+        window.fdc3.addContextListener("fdc3.instrument");
       });
-    </script>
-  </body>
+      closeWindowOnCompletion(window.fdc3);
+    });
+  </script>
+</body>
+
 </html>

--- a/mock/intent-a/index.html
+++ b/mock/intent-a/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App A</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener("aTestingIntent", (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -21,7 +21,7 @@
             type: "fdc3-intent-a-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/intent-b/index.html
+++ b/mock/intent-b/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App B</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener('bTestingIntent', (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -20,7 +20,7 @@
             type: "fdc3-intent-b-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/intent-c/index.html
+++ b/mock/intent-c/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App C</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener('cTestingIntent', (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -17,7 +17,7 @@
             type: "fdc3-intent-c-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -6,20 +6,15 @@ const onFdc3Ready = () => new Promise((resolve) => {
     }
 });
 
-const setupCloseListener = async (fdc3) => {
-    const channel = await fdc3.getOrCreateChannel("fdc3.raiseIntent");
-    await channel.addContextListener("closeWindow", async (context) => {
-        // FDC3 application specific functions called here to close window
-        closeFinsembleWindow();
+const closeWindowOnCompletion = async (fdc3) => {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+        "app-control"
+      );
+    await appControlChannel.addContextListener("closeWindow", async (context) => {
+        window.close();
+
+        //notify app A that window was closed
+        await appControlChannel.broadcast({type: "windowClosed"});
     });
 };
 
-// https://documentation.finsemble.com/docs/smart-desktop/windows-and-workspaces/API-WindowClient/#close
-const closeFinsembleWindow = async () => {
-    if (FSBL) {
-        await FSBL.Clients.WindowClient.close({
-            removeFromWorkspace: false,
-            closeWindow: false
-        });
-    }
-};

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -4,7 +4,7 @@
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
-  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
+  WaitTime: 1500, // The amount of time to wait for mock apps to finish processing
 } as const;
 
 export default constants;

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -4,7 +4,7 @@
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
-  WaitTime: 500, // The amount of time to wait for mock apps to finish processing
+  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
 } as const;
 
 export default constants;

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -4,7 +4,7 @@
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
-  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
+  WaitTime: 500, // The amount of time to wait for mock apps to finish processing
 } as const;
 
 export default constants;

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -33,9 +33,16 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- Add fdc3.instrument context listener to app A\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
+
+          //Add fdc3.instrument context listener
           listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
+            expect(context.type).to.be.oneOf(
+              ["fdc3.instrument", "executionComplete"],
+              errorMessage
+            );
             resolve();
             clearTimeout(timeout);
             return;
@@ -43,7 +50,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
           const channelsAppCommands = [
@@ -51,13 +58,18 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //if no context received throw error
+          await waitForChannelsAppToExecute("executionComplete");
+
+          //wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -68,12 +80,19 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins channel 1\r\n- Add listener of type fdc3.instrument to App A\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins channel 1
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
+
+          //Join system channel 1
           await joinChannel(1);
 
-          //Add context listener to app A
+          //Add fdc3.instrument context listener
           listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
+            expect(context.type).to.be.oneOf(
+              ["fdc3.instrument", "executionComplete"],
+              errorMessage
+            );
             resolve();
             clearTimeout(timeout);
             return;
@@ -86,13 +105,16 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //if no context received throw error
+          //wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -103,23 +125,30 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
+
           const channelsAppCommands = [
             commands.joinSystemChannelOne,
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
-          //Add context listener to app A
+          //Add fdc3.instrument context listener
           listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
+            expect(context.type).to.be.oneOf(
+              ["fdc3.instrument", "executionComplete"],
+              errorMessage
+            );
             resolve();
             clearTimeout(timeout);
             return;
@@ -127,7 +156,10 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //if no context received throw error
+          //wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -138,7 +170,11 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
+
+          //Add context listener
           listener = await window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -154,7 +190,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           joinChannel(1);
 
           const channelsAppCommands = [
@@ -163,13 +199,16 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //if no context received throw error
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -180,9 +219,26 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
           let contextTypes: string[] = [];
+          function checkIfBothContextsReceived() {
+            if (contextTypes.length === 2) {
+              if (
+                !contextTypes.includes("fdc3.contact") ||
+                !contextTypes.includes("fdc3.instrument")
+              ) {
+                assert.fail("Incorrect context received", errorMessage);
+              } else {
+                resolve();
+                clearTimeout(timeout);
+                return;
+              }
+            }
+          }
 
-          //Add context listener to app A
+          //Add context listener
           listener = await window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -204,7 +260,7 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
           const channelsAppCommands = [
@@ -213,28 +269,16 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          function checkIfBothContextsReceived() {
-            if (contextTypes.length === 2) {
-              if (
-                !contextTypes.includes("fdc3.contact") ||
-                !contextTypes.includes("fdc3.instrument")
-              ) {
-                assert.fail("Incorrect context received", errorMessage);
-              } else {
-                resolve();
-                clearTimeout(timeout);
-                return;
-              }
-            }
-          }
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
 
-          //if no context received throw error
+          //If no context received throw error
           await wait();
           reject(
             new Error(`${errorMessage} At least one context was not received`)
@@ -247,7 +291,7 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Add two context listeners to app A
+          //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -261,6 +305,7 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Add fdc3.contact context listener
           listener2 = window.fdc3.addContextListener(
             "fdc3.contact",
             (context) => {
@@ -274,7 +319,7 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //App A joins channel 2
+          //ChannelsApp joins channel 2
           await joinChannel(2);
 
           const channelsAppCommands = [
@@ -283,14 +328,19 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
             buildChannelsAppContext(channelsAppCommands)
           );
 
-          //give listener time to receive context
-          await wait();
+          //Give listener time to receive context
+          await new Promise((resolve) => {
+            timeout = setTimeout(() => {
+              resolve(true);
+            }, 3000);
+          });
+
           resolve();
           return;
         });
@@ -300,11 +350,11 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A unsubscribes the listener\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //listens for when app B execution is complete
-          const waitForChannelsAppToExecute =
-            executionCompleteListener("executionComplete");
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener =
+            waitForChannelsAppToExecute("executionComplete");
 
-          //Add context listener
+          //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -317,10 +367,10 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
-          //unsubscribe from listeners
+          //Unsubscribe from listeners
           if (listener !== undefined) {
             await listener.unsubscribe();
             listener = undefined;
@@ -333,13 +383,14 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await waitForChannelsAppToExecute;
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
           resolve();
           return;
         });
@@ -349,11 +400,7 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //listens for when app B execution is complete
-          const waitForChannelsAppToExecute =
-            executionCompleteListener("executionComplete");
-
-          //Add context listeners to app A
+          //Add fdc3.instrument conext listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -366,7 +413,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App A joins a channel and then joins another
+          //ChannelsApp joins a channel and then joins another
           await joinChannel(1);
           await joinChannel(2);
 
@@ -375,13 +422,19 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands, true)
+            buildChannelsAppContext(channelsAppCommands)
           );
 
-          await waitForChannelsAppToExecute;
+          //Give listener time to receive context
+          await new Promise((resolve) => {
+            timeout = setTimeout(() => {
+              resolve(true);
+            }, 3000);
+          });
+
           resolve();
           return;
         });
@@ -405,7 +458,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
           //App A leaves channel 1
@@ -416,14 +469,19 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
             buildChannelsAppContext(channelsAppCommands)
           );
 
-          //give listener time to receive context
-          await wait();
+          //Give listener time to receive context
+          await new Promise((resolve) => {
+            timeout = setTimeout(() => {
+              resolve(true);
+            }, 3000);
+          });
+
           resolve();
           return;
         });
@@ -440,17 +498,27 @@ export default () =>
         await broadcastAppChannelCloseWindow();
       });
 
-      it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
+      it("Should receive context when app a adds a listener and app B broadcasts to the same app channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
+
         return new Promise(async (resolve, reject) => {
-          //App A retrieves test app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+            "executionComplete",
+            testChannel
+          );
+
+          //Add context listener
           listener = await testChannel.addContextListener(null, (context) => {
-            expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
+            expect(context.type).to.be.oneOf(
+              ["fdc3.instrument", "executionComplete"],
+              errorMessage
+            );
             resolve();
             clearTimeout(timeout);
             return;
@@ -463,13 +531,16 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //if no context received throw error
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -485,16 +556,13 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
             buildChannelsAppContext(channelsAppCommands)
           );
 
-          //give app B time to fully execute
-          await wait();
-
-          //App A retrieves test app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -507,7 +575,7 @@ export default () =>
             return;
           });
 
-          //if no context received throw error
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -524,19 +592,24 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //give app B time to fully execute
-          await wait();
-
-          //App A retrieves test app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
+
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+            "executionComplete",
+            testChannel
+          );
+
+          await waitForChannelsAppToExecute("executionComplete", testChannel);
 
           //Retrieve current context from channel
           await testChannel
@@ -551,7 +624,10 @@ export default () =>
               return;
             });
 
-          //if no context received throw error
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -562,12 +638,18 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves test app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+            "executionComplete",
+            testChannel
+          );
+
+          //Add context listener
           listener = await testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -589,13 +671,16 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //if no context received throw error
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
@@ -607,12 +692,18 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           let contextTypes: string[] = [];
-          //App A retrieves an app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+            "executionComplete",
+            testChannel
+          );
+
+          //Add fdc3.instrument context listener
           listener = await testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -623,7 +714,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Add a second context listener to app A
+          //Add fdc3.contact context listener
           listener2 = await testChannel.addContextListener(
             "fdc3.contact",
             (context) => {
@@ -640,10 +731,10 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           function checkIfBothContextsReceived() {
@@ -661,29 +752,32 @@ export default () =>
             }
           }
 
-          //if no context received throw error
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
       });
 
-      it("Should not receive context when listening for all context types then unsubscribing an app channel before app B broadcasts to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+      it("Should not receive context when unsubscribing an app channel before app B broadcasts to that channel", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves an app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //listens for when app B execution is complete
-          const waitForChannelsAppToExecute = executionCompleteListener(
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
             "executionComplete",
             testChannel
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(null, (context) => {
             reject(
               new Error(`${errorMessage} ${context.type} context received`)
@@ -702,59 +796,17 @@ export default () =>
             commands.broadcastContactContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await waitForChannelsAppToExecute;
-          resolve();
-          return;
-        });
-      });
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
 
-      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
-
-        return new Promise(async (resolve, reject) => {
-          //App A retrieves an app channel
-          const testChannel = await window.fdc3.getOrCreateChannel(
-            "test-channel"
-          );
-
-          //listens for when app B execution is complete
-          const waitForChannelsAppToExecute = executionCompleteListener(
-            "executionComplete",
-            testChannel
-          );
-
-          //Add context listener to app A
-          listener = testChannel.addContextListener(null, (context) => {
-            reject(
-              new Error(`${errorMessage} ${context.type} context received`)
-            );
-            return;
-          });
-
-          validateListenerObject(listener);
-
-          //Unsubscribe from app channel
-          listener.unsubscribe();
-
-          const channelsAppCommands = [
-            commands.retrieveTestAppChannel,
-            commands.broadcastInstrumentContext,
-            commands.broadcastContactContext,
-          ];
-
-          //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open(
-            "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands, true)
-          );
-
-          await waitForChannelsAppToExecute;
+          //Give listener time to receive context
+          wait();
           resolve();
           return;
         });
@@ -764,12 +816,12 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves an app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -788,13 +840,20 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //give listener time to receive context
+          //Give listener time to receive context
+          await new Promise((resolve) => {
+            timeout = setTimeout(() => {
+              resolve(true);
+            }, 3000);
+          });
+
+          //Give listener time to receive context
           await wait();
           resolve();
           return;
@@ -805,9 +864,15 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the first channel that A retrieved\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves an app channel
+          //Retrieve an app channel
           let testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
+          );
+
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+            "executionComplete",
+            testChannel
           );
 
           //App A retrieves a different app channel
@@ -815,7 +880,7 @@ export default () =>
             "a-different-test-channel"
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -834,13 +899,16 @@ export default () =>
             commands.broadcastInstrumentContext,
           ];
 
-          //Open ChannelsApp app then execute commands in order
+          //Open ChannelsApp then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(channelsAppCommands)
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //give listener time to receive context
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Give listener time to receive context
           await wait();
           resolve();
           return;
@@ -850,7 +918,7 @@ export default () =>
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        //App A retrieves test app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
@@ -861,30 +929,39 @@ export default () =>
           commands.broadcastContactContext,
         ];
 
-        //Open ChannelsApp app then execute commands in order
+        //Open ChannelsApp then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
           buildChannelsAppContext(channelsAppCommands)
         );
 
-        //get contexts from app B
+        //get contexts from ChannelsApp
         const context = await testChannel.getCurrentContext("fdc3.instrument");
 
-        expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
+        expect(context.name).to.be.equals("History-item-1", errorMessage);
 
         const contactContext = await testChannel.getCurrentContext(
           "fdc3.contact"
         );
 
-        expect(contactContext.type).to.be.equals("fdc3.contact", errorMessage);
+        expect(contactContext.name).to.be.equals(
+          "History-item-1",
+          errorMessage
+        );
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts a context with multiple history items to the same app channel and A gets current context", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
 
-        //App A retrieves an app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
+        );
+
+        //Listen for when ChannelsApp execution is complete
+        const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
+          "executionComplete",
+          testChannel
         );
 
         const channelsAppCommands = [
@@ -892,16 +969,16 @@ export default () =>
           commands.broadcastInstrumentContext,
         ];
 
-        //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
+        //Open ChannelsApp and execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
           buildChannelsAppContext(channelsAppCommands, true, 2)
         );
 
-        //Give app B time to execute
-        await wait();
+        //Wait for ChannelsApp to execute
+        await resolveExecutionCompleteListener;
 
-        //get contexts from app B
+        //Retrieve fdc3.instrument context
         const context = await testChannel.getCurrentContext("fdc3.instrument");
 
         expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
@@ -911,13 +988,13 @@ export default () =>
       it("Should retrieve the last broadcast context item when app B broadcasts two different contexts to the same app channel and A gets current context", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
 
-        //App A retrieves an app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //listens for when app B execution is complete
-        const waitForChannelsAppToExecute = executionCompleteListener(
+        //Listen for when ChannelsApp execution is complete
+        const resolveExecutionCompleteListener = waitForChannelsAppToExecute(
           "executionComplete",
           testChannel
         );
@@ -928,15 +1005,15 @@ export default () =>
           commands.broadcastContactContext,
         ];
 
-        //Open ChannelsApp app then execute commands in order
+        //Open ChannelsApp then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
           buildChannelsAppContext(channelsAppCommands, true)
         );
 
-        await waitForChannelsAppToExecute;
+        //Wait for ChannelsApp to execute
+        await resolveExecutionCompleteListener;
 
-        //get current context
         const context = await testChannel.getCurrentContext();
 
         if (context === null) {
@@ -1000,7 +1077,7 @@ export default () =>
       }
     }
 
-    const executionCompleteListener = (
+    const waitForChannelsAppToExecute = (
       contextType: string,
       channel?: Channel
     ) => {

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -5,7 +5,7 @@ import APIDocumentation from "../apiDocuments";
 
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
-let timeout: ReturnType<typeof setTimeout>;
+let timeout: number;
 
 export default () =>
   describe("fdc3.broadcast", () => {
@@ -1009,7 +1009,7 @@ export default () =>
 
     async function wait() {
       return new Promise((resolve) => {
-        timeout = setTimeout(() => {
+        timeout = window.setTimeout(() => {
           resolve(true);
         }, constants.WaitTime);
       });

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -26,7 +26,7 @@ export default () =>
       });
 
       afterEach(async () => {
-        await closeChannelsAppWindow(ChannelType.System);
+        await closeChannelsAppWindow();
       });
 
       it("Should receive context when adding a listener then joining a user channel before app B broadcasts context to the same channel", async () => {
@@ -34,15 +34,17 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
           //Add context listener
           listener = await window.fdc3.addContextListener(
             null,
             async (context) => {
-              expect(context.type).to.be.oneOf(
-                ["fdc3.instrument", "executionComplete"],
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
                 errorMessage
               );
               resolve();
@@ -80,8 +82,10 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
           //Join system channel 1
           await joinChannel(1);
@@ -90,8 +94,8 @@ export default () =>
           listener = await window.fdc3.addContextListener(
             null,
             async (context) => {
-              expect(context.type).to.be.oneOf(
-                ["fdc3.instrument", "executionComplete"],
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
                 errorMessage
               );
               resolve();
@@ -126,8 +130,10 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
           const channelsAppCommands = [
             commands.joinSystemChannelOne,
@@ -147,8 +153,8 @@ export default () =>
           listener = await window.fdc3.addContextListener(
             null,
             async (context) => {
-              expect(context.type).to.be.oneOf(
-                ["fdc3.instrument", "executionComplete"],
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
                 errorMessage
               );
               resolve();
@@ -172,8 +178,10 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
           //Add context listener
           listener = await window.fdc3.addContextListener(
@@ -219,8 +227,10 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
           let contextTypes: string[] = [];
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -343,8 +353,10 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //Listen for when ChannelsApp execution is complete
-          const resolveExecutionCompleteListener =
-            waitForContext("executionComplete");
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
           //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
@@ -476,7 +488,7 @@ export default () =>
       });
 
       afterEach(async () => {
-        await closeChannelsAppWindow(ChannelType.App);
+        await closeChannelsAppWindow();
       });
 
       it("Should receive context when app a adds a listener and app B broadcasts to the same app channel", async () => {
@@ -491,15 +503,15 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           //Add context listener
           listener = await testChannel.addContextListener(
             null,
             async (context) => {
-              expect(context.type).to.be.oneOf(
-                ["fdc3.instrument", "executionComplete"],
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
                 errorMessage
               );
               resolve();
@@ -541,7 +553,7 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           const channelsAppCommands = [
@@ -582,7 +594,7 @@ export default () =>
           //Listen for when AppChannel execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           const channelsAppCommands = [
@@ -629,7 +641,7 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           //Add context listener
@@ -681,7 +693,7 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           //Add fdc3.instrument context listener
@@ -753,7 +765,7 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           //Add context listener
@@ -841,7 +853,7 @@ export default () =>
           //Listen for when ChannelsApp execution is complete
           const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
           //App A retrieves a different app channel
@@ -923,7 +935,7 @@ export default () =>
         //Listen for when ChannelsApp execution is complete
         const resolveExecutionCompleteListener = waitForContext(
           "executionComplete",
-          testChannel
+          await window.fdc3.getOrCreateChannel("app-control")
         );
 
         const channelsAppCommands = [
@@ -957,7 +969,7 @@ export default () =>
         //Listen for when ChannelsApp execution is complete
         const resolveExecutionCompleteListener = waitForContext(
           "executionComplete",
-          testChannel
+          await window.fdc3.getOrCreateChannel("app-control")
         );
 
         const channelsAppCommands = [
@@ -979,13 +991,13 @@ export default () =>
 
         if (context === null) {
           assert.fail("No Context retrieved", errorMessage);
-        } else if (context.type === "closeWindow") {
+        } else if (context.type === "fdc3.instrument") {
           assert.fail(
             "Did not retrieve last broadcast context from app B",
             errorMessage
           );
         } else {
-          expect(context.type).to.be.equals("executionComplete", errorMessage);
+          expect(context.type).to.be.equals("fdc3.contact", errorMessage);
         }
       });
     });
@@ -1015,34 +1027,20 @@ export default () =>
       });
     }
 
-    async function closeChannelsAppWindow(channelType: ChannelType) {
-      if (channelType === ChannelType.System) {
-        //Join channel 1
-        await window.fdc3.leaveCurrentChannel();
-        await joinChannel(1);
+    async function closeChannelsAppWindow() {
+      //Tell ChannelsApp to close window
+      const appControlChannel = await broadcastAppChannelCloseWindow();
 
-        //Tell channelsApp to close window
-        await broadcastSystemChannelCloseWindow();
-
-        //Wait for ChannelsApp to respond
-        await waitForContext("windowClosed");
-      } else if (channelType === ChannelType.App) {
-        //Tell ChannelsApp to close window
-        const testChannel = await broadcastAppChannelCloseWindow();
-
-        //Wait for ChannelsApp to respond
-        await waitForContext("windowClosed", testChannel);
-      }
+      //Wait for ChannelsApp to respond
+      await waitForContext("windowClosed", appControlChannel);
     }
 
-    const broadcastSystemChannelCloseWindow = async () => {
-      await window.fdc3.broadcast({ type: "closeWindow" });
-    };
-
     const broadcastAppChannelCloseWindow = async () => {
-      const testChannel = await window.fdc3.getOrCreateChannel("test-channel");
-      await testChannel.broadcast({ type: "closeWindow" });
-      return testChannel;
+      const appControlChannel = await window.fdc3.getOrCreateChannel(
+        "app-control"
+      );
+      await appControlChannel.broadcast({ type: "closeWindow" });
+      return appControlChannel;
     };
 
     async function unsubscribeListeners() {

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -44,7 +44,6 @@ export default () =>
               errorMessage
             );
             resolve();
-            clearTimeout(timeout);
             return;
           });
 
@@ -69,8 +68,7 @@ export default () =>
           //wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //reject if no context received
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -94,7 +92,6 @@ export default () =>
               errorMessage
             );
             resolve();
-            clearTimeout(timeout);
             return;
           });
 
@@ -114,8 +111,7 @@ export default () =>
           //wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -150,7 +146,6 @@ export default () =>
               errorMessage
             );
             resolve();
-            clearTimeout(timeout);
             return;
           });
 
@@ -159,8 +154,7 @@ export default () =>
           //wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -183,7 +177,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              clearTimeout(timeout);
               return;
             }
           );
@@ -208,8 +201,7 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -232,7 +224,6 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
-                clearTimeout(timeout);
                 return;
               }
             }
@@ -278,8 +269,7 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //Reject if no context received
           reject(
             new Error(`${errorMessage} At least one context was not received`)
           );
@@ -335,11 +325,7 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await new Promise((resolve) => {
-            timeout = setTimeout(() => {
-              resolve(true);
-            }, 3000);
-          });
+          wait();
 
           resolve();
           return;
@@ -391,6 +377,7 @@ export default () =>
 
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
+
           resolve();
           return;
         });
@@ -429,11 +416,7 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await new Promise((resolve) => {
-            timeout = setTimeout(() => {
-              resolve(true);
-            }, 3000);
-          });
+          wait();
 
           resolve();
           return;
@@ -476,11 +459,7 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await new Promise((resolve) => {
-            timeout = setTimeout(() => {
-              resolve(true);
-            }, 3000);
-          });
+          wait();
 
           resolve();
           return;
@@ -520,7 +499,6 @@ export default () =>
               errorMessage
             );
             resolve();
-            clearTimeout(timeout);
             return;
           });
 
@@ -540,8 +518,7 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -577,6 +554,7 @@ export default () =>
 
           //If no context received throw error
           await wait();
+
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -620,15 +598,12 @@ export default () =>
                 errorMessage
               );
               resolve();
-              clearTimeout(timeout);
               return;
             });
 
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //If no context received throw error
-          await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -658,7 +633,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              clearTimeout(timeout);
               return;
             }
           );
@@ -681,7 +655,6 @@ export default () =>
           await resolveExecutionCompleteListener;
 
           //If no context received throw error
-          await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -746,7 +719,6 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
-                clearTimeout(timeout);
                 return;
               }
             }
@@ -756,7 +728,6 @@ export default () =>
           await resolveExecutionCompleteListener;
 
           //If no context received throw error
-          await wait();
           reject(new Error(`${errorMessage} No context received`));
           return;
         });
@@ -805,8 +776,6 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //Give listener time to receive context
-          wait();
           resolve();
           return;
         });
@@ -847,14 +816,8 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await new Promise((resolve) => {
-            timeout = setTimeout(() => {
-              resolve(true);
-            }, 3000);
-          });
+          wait();
 
-          //Give listener time to receive context
-          await wait();
           resolve();
           return;
         });
@@ -887,7 +850,6 @@ export default () =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
               );
-              clearTimeout(timeout);
               return;
             }
           );
@@ -908,8 +870,6 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
 
-          //Give listener time to receive context
-          await wait();
           resolve();
           return;
         });

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -829,13 +829,13 @@ export default () =>
       });
     };
 
-    function buildChannelsAppContext(mockAppCommands : any[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
+    function buildChannelsAppContext(mockAppCommands : Commands[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
         settings: {
-          notifyAppAOnCompletion: notifyAppAOnCompletion || false,
-          broadcastTwoHistoryItems: broadcastTwoHistoryItems || false
+          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
+          broadcastTwoHistoryItems: broadcastTwoHistoryItems ?? false
         }
       };
     } 

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -425,7 +425,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -446,7 +446,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -483,7 +483,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -543,7 +543,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -593,7 +593,7 @@ export default () =>
           validateListenerObject(listener2);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -651,7 +651,7 @@ export default () =>
           listener.unsubscribe();
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -695,7 +695,7 @@ export default () =>
           listener.unsubscribe();
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
             commands.broadcastContactContext,
           ];
@@ -732,7 +732,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -774,7 +774,7 @@ export default () =>
           validateListenerObject(listener);
 
           const channelsAppCommands = [
-            commands.retrieveTestChannel,
+            commands.retrieveTestAppChannel,
             commands.broadcastInstrumentContext,
           ];
 
@@ -799,7 +799,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
           commands.broadcastContactContext,
         ];
@@ -831,7 +831,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
         ];
 
@@ -866,7 +866,7 @@ export default () =>
         );
 
         const channelsAppCommands = [
-          commands.retrieveTestChannel,
+          commands.retrieveTestAppChannel,
           commands.broadcastInstrumentContext,
           commands.broadcastContactContext,
         ];
@@ -986,7 +986,7 @@ export default () =>
 
 const commands = {
   joinSystemChannelOne: "joinSystemChannelOne",
-  retrieveTestChannel: "retrieveTestChannel",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",
 };

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -43,23 +43,15 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -83,23 +75,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -112,23 +96,15 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //App A joins channel 1
@@ -169,24 +145,16 @@ export default () =>
           //App A joins channel 1
           joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -226,24 +194,16 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           function checkIfBothContextsReceived() {
@@ -295,24 +255,16 @@ export default () =>
           //App A joins channel 2
           await joinChannel(2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -351,23 +303,15 @@ export default () =>
             assert.fail("Listener undefined", errorMessage);
           }
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -398,23 +342,15 @@ export default () =>
           await joinChannel(1);
           await joinChannel(2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -443,23 +379,15 @@ export default () =>
           //App A leaves channel 1
           await window.fdc3.leaveCurrentChannel();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.user,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.joinUserChannelOne,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -496,23 +424,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -525,23 +445,15 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give app B time to fully execute
@@ -570,24 +482,16 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give app B time to fully execute
@@ -638,24 +542,16 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //if no context received throw error
@@ -696,24 +592,16 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           function checkIfBothContextsReceived() {
@@ -762,24 +650,16 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -787,7 +667,7 @@ export default () =>
         });
       });
 
-      it.only("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
+      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
@@ -814,24 +694,16 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: true,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-                commands.broadcastContactContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
           await executionCompleteContext;
@@ -859,23 +731,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -909,23 +773,15 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Set ChannelsApp config
-          const channelsAppConfig: IChannelsAppConfig = {
-            channelType: channelType.app,
-            notifyAppAOnCompletion: false,
-            historyItems: 1,
-          };
+          const channelsAppCommands = [
+            commands.retrieveTestChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open(
             "ChannelsApp",
-            buildChannelsAppContext(
-              [
-                commands.retrieveTestChannel,
-                commands.broadcastInstrumentContext,
-              ],
-              channelsAppConfig
-            )
+            buildChannelsAppContext(channelsAppCommands)
           );
 
           //give listener time to receive context
@@ -942,24 +798,16 @@ export default () =>
           "test-channel"
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: false,
-          historyItems: 1,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [
-              commands.retrieveTestChannel,
-              commands.broadcastInstrumentContext,
-              commands.broadcastContactContext,
-            ],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands)
         );
 
         //get contexts from app B
@@ -982,20 +830,15 @@ export default () =>
           "test-channel"
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: true,
-          historyItems: 2,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+        ];
 
         //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [commands.retrieveTestChannel, commands.broadcastInstrumentContext],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands, true, 2)
         );
 
         //Give app B time to execute
@@ -1022,24 +865,16 @@ export default () =>
           testChannel
         );
 
-        //Set ChannelsApp config
-        const channelsAppConfig: IChannelsAppConfig = {
-          channelType: channelType.app,
-          notifyAppAOnCompletion: true,
-          historyItems: 1,
-        };
+        const channelsAppCommands = [
+          commands.retrieveTestChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open(
           "ChannelsApp",
-          buildChannelsAppContext(
-            [
-              commands.retrieveTestChannel,
-              commands.broadcastInstrumentContext,
-              commands.broadcastContactContext,
-            ],
-            channelsAppConfig
-          )
+          buildChannelsAppContext(channelsAppCommands, true)
         );
 
         await executionCompleteContext;
@@ -1135,33 +970,22 @@ export default () =>
 
     function buildChannelsAppContext(
       mockAppCommands: string[],
-      channelsAppConfig: IChannelsAppConfig
+      notifyAppAOnCompletion?: boolean,
+      historyItems?: number
     ) {
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
         config: {
-          channelType: channelsAppConfig.channelType,
-          notifyAppAOnCompletion: channelsAppConfig.notifyAppAOnCompletion,
-          historyItems: channelsAppConfig.historyItems,
+          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
+          historyItems: historyItems ?? 1,
         },
       };
     }
   });
 
-interface IChannelsAppConfig {
-  channelType: string;
-  notifyAppAOnCompletion: boolean;
-  historyItems: number;
-}
-
-const channelType = {
-  user: "user",
-  app: "app",
-};
-
 const commands = {
-  joinUserChannelOne: "joinUserChannelOne",
+  joinSystemChannelOne: "joinSystemChannelOne",
   retrieveTestChannel: "retrieveTestChannel",
   broadcastInstrumentContext: "broadcastInstrumentContext",
   broadcastContactContext: "broadcastContactContext",

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -301,7 +301,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //listens for when app B execution is complete
-          const executionCompleteContext =
+          const waitForChannelsAppToExecute =
             executionCompleteListener("executionComplete");
 
           //Add context listener
@@ -339,7 +339,7 @@ export default () =>
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await executionCompleteContext;
+          await waitForChannelsAppToExecute;
           resolve();
           return;
         });
@@ -350,7 +350,7 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           //listens for when app B execution is complete
-          const executionCompleteContext =
+          const waitForChannelsAppToExecute =
             executionCompleteListener("executionComplete");
 
           //Add context listeners to app A
@@ -381,7 +381,7 @@ export default () =>
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await executionCompleteContext;
+          await waitForChannelsAppToExecute;
           resolve();
           return;
         });
@@ -678,7 +678,7 @@ export default () =>
           );
 
           //listens for when app B execution is complete
-          const executionCompleteContext = executionCompleteListener(
+          const waitForChannelsAppToExecute = executionCompleteListener(
             "executionComplete",
             testChannel
           );
@@ -708,7 +708,7 @@ export default () =>
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await executionCompleteContext;
+          await waitForChannelsAppToExecute;
           resolve();
           return;
         });
@@ -724,7 +724,7 @@ export default () =>
           );
 
           //listens for when app B execution is complete
-          const executionCompleteContext = executionCompleteListener(
+          const waitForChannelsAppToExecute = executionCompleteListener(
             "executionComplete",
             testChannel
           );
@@ -754,7 +754,7 @@ export default () =>
             buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          await executionCompleteContext;
+          await waitForChannelsAppToExecute;
           resolve();
           return;
         });
@@ -917,7 +917,7 @@ export default () =>
         );
 
         //listens for when app B execution is complete
-        const executionCompleteContext = executionCompleteListener(
+        const waitForChannelsAppToExecute = executionCompleteListener(
           "executionComplete",
           testChannel
         );
@@ -934,7 +934,7 @@ export default () =>
           buildChannelsAppContext(channelsAppCommands, true)
         );
 
-        await executionCompleteContext;
+        await waitForChannelsAppToExecute;
 
         //get current context
         const context = await testChannel.getCurrentContext();

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,10 +1,11 @@
-import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
+import { Listener, Channel, Context } from "@finos/fdc3";
 import { assert, expect } from "chai";
 import constants from "../constants";
 import APIDocumentation from "../apiDocuments";
 
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
+let timeout: NodeJS.Timeout;
 
 export default () =>
   describe("fdc3.broadcast", () => {
@@ -36,6 +37,8 @@ export default () =>
           listener = await window.fdc3.addContextListener(null, (context) => {
             expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
             resolve();
+            clearTimeout(timeout);
+            return;
           });
 
           validateListenerObject(listener);
@@ -57,6 +60,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -71,6 +75,8 @@ export default () =>
           listener = await window.fdc3.addContextListener(null, (context) => {
             expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
             resolve();
+            clearTimeout(timeout);
+            return;
           });
 
           validateListenerObject(listener);
@@ -89,6 +95,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -114,6 +121,8 @@ export default () =>
           listener = await window.fdc3.addContextListener(null, (context) => {
             expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
             resolve();
+            clearTimeout(timeout);
+            return;
           });
 
           validateListenerObject(listener);
@@ -121,6 +130,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -137,6 +147,8 @@ export default () =>
                 errorMessage
               );
               resolve();
+              clearTimeout(timeout);
+              return;
             }
           );
 
@@ -160,6 +172,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -215,6 +228,8 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
+                clearTimeout(timeout);
+                return;
               }
             }
           }
@@ -224,6 +239,7 @@ export default () =>
           reject(
             new Error(`${errorMessage} At least one context was not received`)
           );
+          return;
         });
       });
 
@@ -234,20 +250,26 @@ export default () =>
           //Add two context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
           listener2 = window.fdc3.addContextListener(
             "fdc3.contact",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener2);
@@ -270,6 +292,7 @@ export default () =>
           //give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
 
@@ -284,10 +307,12 @@ export default () =>
           //Add context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              return;
+            }
           );
 
           validateListenerObject(listener);
@@ -316,6 +341,7 @@ export default () =>
 
           await executionCompleteContext;
           resolve();
+          return;
         });
       });
 
@@ -330,10 +356,12 @@ export default () =>
           //Add context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              return;
+            }
           );
 
           validateListenerObject(listener);
@@ -355,6 +383,7 @@ export default () =>
 
           await executionCompleteContext;
           resolve();
+          return;
         });
       });
 
@@ -365,10 +394,13 @@ export default () =>
           //Add a context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
@@ -393,6 +425,7 @@ export default () =>
           //give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
     });
@@ -419,6 +452,8 @@ export default () =>
           listener = await testChannel.addContextListener(null, (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
+            clearTimeout(timeout);
+            return;
           });
 
           validateListenerObject(listener);
@@ -437,6 +472,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -467,11 +503,14 @@ export default () =>
           await testChannel.getCurrentContext().then((context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
+            clearTimeout(timeout);
+            return;
           });
 
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -508,11 +547,14 @@ export default () =>
                 errorMessage
               );
               resolve();
+              clearTimeout(timeout);
+              return;
             });
 
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -534,6 +576,8 @@ export default () =>
                 errorMessage
               );
               resolve();
+              clearTimeout(timeout);
+              return;
             }
           );
 
@@ -554,6 +598,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -610,6 +655,8 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
+                clearTimeout(timeout);
+                return;
               }
             }
           }
@@ -617,6 +664,7 @@ export default () =>
           //if no context received throw error
           await wait();
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -640,6 +688,7 @@ export default () =>
             reject(
               new Error(`${errorMessage} ${context.type} context received`)
             );
+            return;
           });
 
           validateListenerObject(listener);
@@ -661,6 +710,7 @@ export default () =>
 
           await executionCompleteContext;
           resolve();
+          return;
         });
       });
 
@@ -684,6 +734,7 @@ export default () =>
             reject(
               new Error(`${errorMessage} ${context.type} context received`)
             );
+            return;
           });
 
           validateListenerObject(listener);
@@ -705,6 +756,7 @@ export default () =>
 
           await executionCompleteContext;
           resolve();
+          return;
         });
       });
 
@@ -720,10 +772,13 @@ export default () =>
           //Add context listener to app A
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
@@ -742,6 +797,7 @@ export default () =>
           //give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
 
@@ -762,10 +818,13 @@ export default () =>
           //Add context listener to app A
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
@@ -784,6 +843,7 @@ export default () =>
           //give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
 
@@ -910,11 +970,11 @@ export default () =>
     }
 
     async function wait() {
-      return new Promise((resolve) =>
-        setTimeout(() => {
+      return new Promise((resolve) => {
+        timeout = setTimeout(() => {
           resolve(true);
-        }, constants.WaitTime)
-      );
+        }, constants.WaitTime);
+      });
     }
 
     const broadcastSystemChannelCloseWindow = async () => {

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -409,9 +409,8 @@ export default () =>
 
       it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
-
         return new Promise(async (resolve, reject) => {
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -459,7 +458,7 @@ export default () =>
           //give app B time to fully execute
           await wait();
 
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -497,7 +496,7 @@ export default () =>
           //give app B time to fully execute
           await wait();
 
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -523,7 +522,7 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A retrieves app channel
+          //App A retrieves test app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -793,7 +792,7 @@ export default () =>
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        //App A retrieves app channel
+        //App A retrieves test app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,7 +1,6 @@
 import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
 import { assert, expect } from "chai";
 import constants from "../constants";
-import fdc3AddContextListener from "./fdc3.addContextListener";
 import APIDocumentation from "../apiDocuments";
 
 const documentation =
@@ -44,11 +43,24 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -71,11 +83,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -87,11 +112,24 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //App A joins channel 1
           await joinChannel(1);
@@ -131,12 +169,25 @@ export default () =>
           //App A joins channel 1
           joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -175,12 +226,25 @@ export default () =>
           //App A joins channel 1
           await joinChannel(1);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -231,12 +295,25 @@ export default () =>
           //App A joins channel 2
           await joinChannel(2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -274,11 +351,24 @@ export default () =>
             assert.fail("Listener undefined", errorMessage);
           }
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -308,11 +398,24 @@ export default () =>
           await joinChannel(1);
           await joinChannel(2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -340,11 +443,24 @@ export default () =>
           //App A leaves channel 1
           await window.fdc3.leaveCurrentChannel();
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.user,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinUserChannelOne, 
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.joinUserChannelOne,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -380,11 +496,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -396,11 +525,24 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give app B time to fully execute
           await wait();
@@ -428,12 +570,25 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give app B time to fully execute
           await wait();
@@ -483,12 +638,25 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //if no context received throw error
           await wait();
@@ -528,12 +696,25 @@ export default () =>
 
           validateListenerObject(listener2);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -581,20 +762,32 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ], true));
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
 
+          //Open ChannelsApp app then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
         });
       });
 
-      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
+      it.only("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
@@ -621,12 +814,25 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: true,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext,
-            Commands.BroadcastContactContext
-          ], true));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+                commands.broadcastContactContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           await executionCompleteContext;
           resolve();
@@ -653,11 +859,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -690,11 +909,24 @@ export default () =>
 
           validateListenerObject(listener);
 
+          //Set ChannelsApp config
+          const channelsAppConfig: IChannelsAppConfig = {
+            channelType: channelType.app,
+            notifyAppAOnCompletion: false,
+            historyItems: 1,
+          };
+
           //Open ChannelsApp app then execute commands in order
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ]));
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(
+              [
+                commands.retrieveTestChannel,
+                commands.broadcastInstrumentContext,
+              ],
+              channelsAppConfig
+            )
+          );
 
           //give listener time to receive context
           await wait();
@@ -710,12 +942,25 @@ export default () =>
           "test-channel"
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: false,
+          historyItems: 1,
+        };
+
         //Open ChannelsApp app then execute commands in order
-        await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.RetrieveTestChannel,
-          Commands.BroadcastInstrumentContext,
-          Commands.BroadcastContactContext
-        ]));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [
+              commands.retrieveTestChannel,
+              commands.broadcastInstrumentContext,
+              commands.broadcastContactContext,
+            ],
+            channelsAppConfig
+          )
+        );
 
         //get contexts from app B
         const context = await testChannel.getCurrentContext("fdc3.instrument");
@@ -737,11 +982,21 @@ export default () =>
           "test-channel"
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: true,
+          historyItems: 2,
+        };
+
         //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
-          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.RetrieveTestChannel,
-            Commands.BroadcastInstrumentContext
-          ], false, true));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [commands.retrieveTestChannel, commands.broadcastInstrumentContext],
+            channelsAppConfig
+          )
+        );
 
         //Give app B time to execute
         await wait();
@@ -767,12 +1022,25 @@ export default () =>
           testChannel
         );
 
+        //Set ChannelsApp config
+        const channelsAppConfig: IChannelsAppConfig = {
+          channelType: channelType.app,
+          notifyAppAOnCompletion: true,
+          historyItems: 1,
+        };
+
         //Open ChannelsApp app then execute commands in order
-        await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.RetrieveTestChannel,
-          Commands.BroadcastInstrumentContext,
-          Commands.BroadcastContactContext
-        ], true));
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(
+            [
+              commands.retrieveTestChannel,
+              commands.broadcastInstrumentContext,
+              commands.broadcastContactContext,
+            ],
+            channelsAppConfig
+          )
+        );
 
         await executionCompleteContext;
 
@@ -865,21 +1133,36 @@ export default () =>
       });
     };
 
-    function buildChannelsAppContext(mockAppCommands : Commands[], notifyAppAOnCompletion?: boolean, broadcastTwoHistoryItems?: boolean, ){
+    function buildChannelsAppContext(
+      mockAppCommands: string[],
+      channelsAppConfig: IChannelsAppConfig
+    ) {
       return {
         type: "channelsAppContext",
         commands: mockAppCommands,
-        settings: {
-          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
-          broadcastTwoHistoryItems: broadcastTwoHistoryItems ?? false
-        }
+        config: {
+          channelType: channelsAppConfig.channelType,
+          notifyAppAOnCompletion: channelsAppConfig.notifyAppAOnCompletion,
+          historyItems: channelsAppConfig.historyItems,
+        },
       };
-    } 
-
-    enum Commands {
-      JoinUserChannelOne,
-      RetrieveTestChannel,
-      BroadcastInstrumentContext,
-      BroadcastContactContext,
     }
   });
+
+interface IChannelsAppConfig {
+  channelType: string;
+  notifyAppAOnCompletion: boolean;
+  historyItems: number;
+}
+
+const channelType = {
+  user: "user",
+  app: "app",
+};
+
+const commands = {
+  joinUserChannelOne: "joinUserChannelOne",
+  retrieveTestChannel: "retrieveTestChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1100,7 +1100,3 @@ const commands = {
   broadcastContactContext: "broadcastContactContext",
 };
 
-enum ChannelType {
-  System,
-  App,
-}

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -364,10 +364,10 @@ export default () =>
       });
 
       it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds adds a context listener of type null\r\n- App B joins the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -382,7 +382,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -392,31 +392,67 @@ export default () =>
         });
       });
 
-      it("Should receive context when app B broadcasts context to an app channel before A joins and listens on the same channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A joins the same app channel as B\r\n- App A adds a context listener of type null${documentation}`;
+      it("Should receive context when app B broadcasts context to an app channel before A retrieves current context", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
           //give app B time to fully execute
           await wait();
 
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
-          listener = await testChannel.addContextListener(null, (context) => {
+          //Retrieve current context from channel
+          await testChannel.getCurrentContext().then((context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
           });
 
           validateListenerObject(listener);
+
+          //if no context received throw error
+          await wait();
+          reject(new Error(`${errorMessage} No context received`));
+        });
+      });
+
+      it("Should receive context of correct type when app B broadcasts multiple contexts to an app channel before A retrieves current context of a specified type", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
+
+        return new Promise(async (resolve, reject) => {
+          //Open ChannelsApp app then execute commands in order
+          await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
+            Commands.RetrieveTestChannel,
+            Commands.BroadcastInstrumentContext,
+            Commands.BroadcastContactContext
+          ]));
+
+          //give app B time to fully execute
+          await wait();
+
+          //App A retrieves app channel
+          const testChannel = await window.fdc3.getOrCreateChannel(
+            "test-channel"
+          );
+
+          //Retrieve current context from channel
+          await testChannel
+            .getCurrentContext("fdc3.instrument")
+            .then((context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+            });
 
           //if no context received throw error
           await wait();
@@ -425,10 +461,10 @@ export default () =>
       });
 
       it("Should only receive the listened context when app B broadcasts multiple contexts to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -449,7 +485,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ]));
@@ -461,11 +497,11 @@ export default () =>
       });
 
       it("Should receive multiple contexts when app B broadcasts the listened types to the same app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument and fdc3.contact\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
           let contextTypes: string[] = [];
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -494,7 +530,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ]));
@@ -519,10 +555,10 @@ export default () =>
       });
 
       it("Should not receive context when listening for all context types then unsubscribing an app channel before app B broadcasts to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -547,7 +583,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ], true));
@@ -559,10 +595,10 @@ export default () =>
       });
 
       it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B joins the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
@@ -587,7 +623,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext,
             Commands.BroadcastContactContext
           ], true));
@@ -598,10 +634,10 @@ export default () =>
       });
 
       it("Should not receive context when app B broadcasts context to a different app channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -619,7 +655,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -629,16 +665,16 @@ export default () =>
         });
       });
 
-      it("Should not receive context when joining two different app channels before app B broadcasts the listened type to the first channel that was joined", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B joins the first channel that A joined\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
+      it("Should not receive context when retrieving two different app channels before app B broadcasts the listened type to the first channel that was retrieved", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the first channel that A retrieved\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins app channel
+          //App A retrieves an app channel
           let testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //App A joins different app channel
+          //App A retrieves a different app channel
           testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
@@ -656,7 +692,7 @@ export default () =>
 
           //Open ChannelsApp app then execute commands in order
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ]));
 
@@ -667,16 +703,16 @@ export default () =>
       });
 
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.JoinTestChannel,
+          Commands.RetrieveTestChannel,
           Commands.BroadcastInstrumentContext,
           Commands.BroadcastContactContext
         ]));
@@ -694,16 +730,16 @@ export default () =>
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts a context with multiple history items to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //Open ChannelsApp app, join test channel then broadcast two different intrument contexts
+        //Open ChannelsApp app, retrieve test channel then broadcast two different intrument contexts
           await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-            Commands.JoinTestChannel,
+            Commands.RetrieveTestChannel,
             Commands.BroadcastInstrumentContext
           ], false, true));
 
@@ -718,9 +754,9 @@ export default () =>
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts two different contexts to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
 
-        //App A joins app channel
+        //App A retrieves an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
@@ -733,7 +769,7 @@ export default () =>
 
         //Open ChannelsApp app then execute commands in order
         await window.fdc3.open("ChannelsApp", buildChannelsAppContext([
-          Commands.JoinTestChannel,
+          Commands.RetrieveTestChannel,
           Commands.BroadcastInstrumentContext,
           Commands.BroadcastContactContext
         ], true));
@@ -842,7 +878,7 @@ export default () =>
 
     enum Commands {
       JoinUserChannelOne,
-      JoinTestChannel,
+      RetrieveTestChannel,
       BroadcastInstrumentContext,
       BroadcastContactContext,
     }

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -5,7 +5,7 @@ import APIDocumentation from "../apiDocuments";
 
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
-let timeout: NodeJS.Timeout;
+let timeout: ReturnType<typeof setTimeout>;
 
 export default () =>
   describe("fdc3.broadcast", () => {

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -6,6 +6,7 @@ import constants from "../constants";
 
 const appBName = "MockApp";
 const appBId = "MockAppId";
+let timeout: NodeJS.Timeout;
 
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
@@ -18,6 +19,7 @@ const createReceiver = (contextType: string) => {
       contextType,
       (context) => {
         resolve(context);
+        clearTimeout(timeout);
         listener.unsubscribe();
       }
     );
@@ -31,10 +33,11 @@ const createReceiver = (contextType: string) => {
 };
 
 async function wait() {
-  return new Promise((resolve) =>
-    setTimeout(() => {
-      resolve(true);
-    }, 3000)
+  return new Promise(
+    (resolve) =>
+      (timeout = setTimeout(() => {
+        resolve(true);
+      }, constants.WaitTime))
   );
 }
 
@@ -47,25 +50,19 @@ export default () =>
   describe("fdc3.open", () => {
     it("Can open app B from app A with no context and string as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open(appBName);
-
       await result;
     });
 
     it("Can open app B from app A with no context and AppMetadata (name) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open({ name: appBName });
-
       await result;
     });
 
     it("Can open app B from app A with no context and AppMetadata (name and appId) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open({ name: appBName, appId: appBId });
-
       await result;
     });
 

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -35,7 +35,7 @@ const createReceiver = (contextType: string) => {
 async function wait() {
   return new Promise(
     (resolve) =>
-      (timeout = setTimeout(() => {
+      (timeout = window.setTimeout(() => {
         resolve(true);
       }, constants.WaitTime))
   );

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -1,6 +1,8 @@
 import { OpenError, Context } from "@finos/fdc3";
+import { resolveObjectURL } from "buffer";
 import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
+import constants from "../constants";
 
 const appBName = "MockApp";
 const appBId = "MockAppId";
@@ -8,7 +10,7 @@ const appBId = "MockAppId";
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
 const createReceiver = (contextType: string) => {
-  const messageReceived = new Promise<Context>(async (resolve) => {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
     await window.fdc3.getOrCreateChannel("FDC3-Conformance-Channel");
     await window.fdc3.joinChannel("FDC3-Conformance-Channel");
 
@@ -19,10 +21,22 @@ const createReceiver = (contextType: string) => {
         listener.unsubscribe();
       }
     );
+
+    //reject promise if no context received
+    await wait();
+    reject(new Error("No context received from app B"));
   });
 
   return messageReceived;
 };
+
+async function wait() {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime)
+  );
+}
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation.open + "\r\nCause";
 

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -6,7 +6,7 @@ import constants from "../constants";
 
 const appBName = "MockApp";
 const appBId = "MockAppId";
-let timeout: NodeJS.Timeout;
+let timeout: number;
 
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -33,12 +33,11 @@ const createReceiver = (contextType: string) => {
 };
 
 async function wait() {
-  return new Promise(
-    (resolve) =>
-      (timeout = window.setTimeout(() => {
-        resolve(true);
-      }, constants.WaitTime))
-  );
+  return new Promise((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime);
+  });
 }
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation.open + "\r\nCause";
@@ -53,19 +52,16 @@ export default () =>
       await window.fdc3.open(appBName);
       await result;
     });
-
     it("Can open app B from app A with no context and AppMetadata (name) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
       await window.fdc3.open({ name: appBName });
       await result;
     });
-
     it("Can open app B from app A with no context and AppMetadata (name and appId) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
       await window.fdc3.open({ name: appBName, appId: appBId });
       await result;
     });
-
     it("Receive AppNotFound error when targeting non-existent app name as target", async () => {
       try {
         await window.fdc3.open("ThisAppDoesNotExist");
@@ -74,7 +70,6 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Receive AppNotFound error when targeting non-existent app AppMetadata (name) as target", async () => {
       try {
         await window.fdc3.open({ name: "ThisAppDoesNotExist" });
@@ -83,7 +78,6 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Receive AppNotFound error when targeting non-existent app AppMetadata (name and appId) as target", async () => {
       try {
         await window.fdc3.open({
@@ -95,15 +89,12 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Can open app B from app A with context and AppMetadata (name) as target", async () => {
       const receiver = createReceiver("fdc3-conformance-context-received");
-
       await window.fdc3.open(
         { name: appBName },
         { name: "context", type: "fdc3.testReceiver" }
       );
-
       const receivedValue = (await receiver) as any;
       expect(receivedValue.context.name).to.eq("context", openDocs);
       expect(receivedValue.context.type).to.eq("fdc3.testReceiver", openDocs);

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -34,7 +34,7 @@ async function wait() {
   return new Promise((resolve) =>
     setTimeout(() => {
       resolve(true);
-    }, constants.WaitTime)
+    }, 3000)
   );
 }
 

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -187,5 +187,5 @@ const validateIntentResolution = (
       appName,
       raiseIntentDocs
     );
-  } else assert.fail("Incorrect type returned");
+  } else assert.fail("Invalid intent resolution object");
 };

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -25,7 +25,6 @@ const createReceiver = (contextType: string) => {
 
     //if no context received reject promise
     await wait();
-    await wait();
     reject(new Error("No context received from app B"));
   });
 

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -5,10 +5,11 @@ import {
   raiseIntent,
   ResolveError,
 } from "@finos/fdc3";
-import { resolveObjectURL } from "buffer";
 import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
 import constants from "../constants";
+
+let timeout: NodeJS.Timeout;
 
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
@@ -23,6 +24,7 @@ const createReceiver = (contextType: string) => {
     );
 
     //if no context received reject promise
+    await wait();
     await wait();
     reject(new Error("No context received from app B"));
   });
@@ -197,9 +199,10 @@ const validateIntentResolution = (
 };
 
 async function wait() {
-  return new Promise((resolve) =>
-    setTimeout(() => {
-      resolve(true);
-    }, 3000)
+  return new Promise(
+    (resolve) =>
+      (timeout = setTimeout(() => {
+        resolve(true);
+      }, constants.WaitTime))
   );
 }

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -200,6 +200,6 @@ async function wait() {
   return new Promise((resolve) =>
     setTimeout(() => {
       resolve(true);
-    }, constants.WaitTime)
+    }, 3000)
   );
 }

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -1,5 +1,6 @@
 import {
   AppMetadata,
+  Channel,
   Context,
   IntentResolution,
   raiseIntent,
@@ -10,27 +11,6 @@ import APIDocumentation from "../apiDocuments";
 import constants from "../constants";
 
 let timeout: number;
-
-// creates a channel and subscribes for broadcast contexts. This is
-// used by the 'mock app' to send messages back to the test runner for validation
-const createReceiver = (contextType: string) => {
-  const messageReceived = new Promise<Context>(async (resolve, reject) => {
-    const listener = await window.fdc3.addContextListener(
-      contextType,
-      (context) => {
-        resolve(context);
-        clearTimeout(timeout);
-        listener.unsubscribe();
-      }
-    );
-
-    //if no context received reject promise
-    await wait();
-    reject(new Error("No context received from app B"));
-  });
-
-  return messageReceived;
-};
 
 const raiseIntentDocs =
   "\r\nDocumentation: " + APIDocumentation.raiseIntent + "\r\nCause";
@@ -45,17 +25,9 @@ export default () =>
       await window.fdc3.joinChannel("fdc3.raiseIntent");
     });
 
-    const broadcastCloseWindow = async () => {
-      await window.fdc3.broadcast({ type: "closeWindow" });
-      return new Promise<void>((resolve) => setTimeout(() => resolve(), 1000)); // Wait until close window event is handled
-    };
-
-    beforeEach(async () => {
-      await broadcastCloseWindow();
-    });
-
     afterEach(async () => {
       await broadcastCloseWindow();
+      await waitForMockAppToClose();
     });
 
     it("Should start app intent-b when raising intent 'sharedTestingIntent1' with context 'testContextY'", async () => {
@@ -84,19 +56,6 @@ export default () =>
       await result;
     });
 
-    it("Should start app intent-a when targeted (name and appId) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
-      const result = createReceiver("fdc3-intent-a-opened");
-      const intentResolution = await window.fdc3.raiseIntent(
-        "aTestingIntent",
-        {
-          type: "testContextX",
-        },
-        { name: "IntentAppA", appId: "IntentAppAId" }
-      );
-      validateIntentResolution("IntentAppA", intentResolution);
-      await result;
-    });
-
     it("Should start app intent-a when targeted (name) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
       const result = createReceiver("fdc3-intent-a-opened");
       const intentResolution = await window.fdc3.raiseIntent(
@@ -107,6 +66,19 @@ export default () =>
         { name: "IntentAppA" }
       );
 
+      validateIntentResolution("IntentAppA", intentResolution);
+      await result;
+    });
+
+    it("Should start app intent-a when targeted (name and appId) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
+      const result = createReceiver("fdc3-intent-a-opened");
+      const intentResolution = await window.fdc3.raiseIntent(
+        "aTestingIntent",
+        {
+          type: "testContextX",
+        },
+        { name: "IntentAppA", appId: "IntentAppAId" }
+      );
       validateIntentResolution("IntentAppA", intentResolution);
       await result;
     });
@@ -123,6 +95,11 @@ export default () =>
         assert.fail("Error was not thrown");
       } catch (ex) {
         expect(ex).to.have.property("message", ResolveError.NoAppsFound);
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -142,6 +119,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -161,6 +143,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -180,6 +167,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
   });
@@ -199,10 +191,57 @@ const validateIntentResolution = (
 };
 
 async function wait() {
-  return new Promise(
-    (resolve) =>
-      (timeout = window.setTimeout(() => {
-        resolve(true);
-      }, constants.WaitTime))
-  );
+  return new Promise((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime);
+  });
+}
+
+const broadcastCloseWindow = async () => {
+  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+  await appControlChannel.broadcast({ type: "closeWindow" });
+};
+
+// creates a channel and subscribes for broadcast contexts. This is
+// used by the 'mock app' to send messages back to the test runner for validation
+const createReceiver = (contextType: string) => {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    const listener = await window.fdc3.addContextListener(
+      contextType,
+      (context) => {
+        resolve(context);
+        clearTimeout(timeout);
+        listener.unsubscribe();
+      }
+    );
+
+    //if no context received reject promise
+    await wait();
+    reject(new Error("No context received from app B"));
+  });
+
+  return messageReceived;
+};
+
+async function waitForMockAppToClose() {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    const listener = await appControlChannel.addContextListener(
+      "windowClosed",
+      (context) => {
+        resolve(context);
+        clearTimeout(timeout);
+        listener.unsubscribe();
+      }
+    );
+
+    //if no context received reject promise
+    await wait();
+    reject(new Error("windowClosed context not received from app B"));
+  });
+
+  return messageReceived;
 }

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -9,7 +9,7 @@ import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
 import constants from "../constants";
 
-let timeout: NodeJS.Timeout;
+let timeout: number;
 
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
@@ -19,6 +19,7 @@ const createReceiver = (contextType: string) => {
       contextType,
       (context) => {
         resolve(context);
+        clearTimeout(timeout);
         listener.unsubscribe();
       }
     );
@@ -200,7 +201,7 @@ const validateIntentResolution = (
 async function wait() {
   return new Promise(
     (resolve) =>
-      (timeout = setTimeout(() => {
+      (timeout = window.setTimeout(() => {
         resolve(true);
       }, constants.WaitTime))
   );


### PR DESCRIPTION
This is a pull request that addresses the following points from issue [#74](https://github.com/finos/FDC3-conformance-framework/issues/74):

-3) Some tests are hard to grok:
>Much of the Channel tests' code has been refactored for improved test readability and efficiency. 

-4) Wait times and total runtime:
> Timeouts now get cancelled if the promise above resolves first.
> Removed wait times wherever possible.
> Overall runtime speed is much faster.

-5) Window closing:
>The timeout that waits for the window to close should have been removed and was left there by mistake. This has now been fixed for all tests.
>All tests now use `window.close` to close the mock app windows

This pull request also addresses issue [#83](https://github.com/finos/FDC3-conformance-framework/issues/83):
- All messaging between apps related to closing app windows and checking if execution has been completed is now done over a single dedicated app channel named "app-control"


