### PR TITLE
Channel tests refactor and improved test efficiency

### DIFF
--- a/mock/channels/channelService.js
+++ b/mock/channels/channelService.js
@@ -1,40 +1,132 @@
-class AppChannelService {
-    async joinChannel() {
-        return await window.fdc3.getOrCreateChannel("test-channel");
+class Fdc3CommandExecutor {
+  //execute commands in order
+  async executeCommands(orderedCommands, config) {
+    let channel;
+
+    for (const command of orderedCommands) {
+      switch (command) {
+        case commands.joinSystemChannelOne: {
+          channel = await this.joinSystemChannelOne();
+          break;
+        }
+        case commands.retrieveTestAppChannel: {
+          channel = await this.retrieveTestAppChannel();
+          break;
+        }
+        case commands.broadcastInstrumentContext: {
+          await this.broadcastContextItem(
+            "fdc3.instrument",
+            channel,
+            config.historyItems
+          );
+          break;
+        }
+        case commands.broadcastContactContext: {
+          await this.broadcastContextItem(
+            "fdc3.contact",
+            channel,
+            config.historyItems
+          );
+          break;
+        }
+      }
     }
 
-    async broadcast(contextType, historyItem, channel) {
-        await channel.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
-        });
-    }
+    //close ChannelsApp when test is complete
+    await this.closeWindowOnCompletion();
 
-    async addContextListener(contextType, channel) {
-        await channel.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
+    //notify app A that ChannelsApp has finished executing
+    if (config.notifyAppAOnCompletion) {
+      await this.notifyAppAOnCompletion();
     }
-}
+  }
 
-class UserChannelService {
-    async joinChannel() {
-        const channels = await window.fdc3.getSystemChannels();
-        await window.fdc3.joinChannel(channels[0].id);
-        return channels[0];
+  async joinSystemChannelOne() {
+    const channels = await window.fdc3.getSystemChannels();
+    await window.fdc3.joinChannel(channels[0].id);
+    return channels[0];
+  }
+
+  //retrieve/create "test-channel" app channel
+  async retrieveTestAppChannel() {
+    return await window.fdc3.getOrCreateChannel("test-channel");
+  }
+
+  //get broadcast service and broadcast the given context type
+  async broadcastContextItem(contextType, channel, historyItems) {
+    let broadcastService = this.getBroadcastService(channel.type);
+    await broadcastService.broadcast(contextType, historyItems, channel);
+  }
+
+  //get app/system channel broadcast service
+  getBroadcastService(currentChannelType) {
+    if (currentChannelType === channelType.system) {
+      return this.systemChannelBroadcastService;
+    } else if (currentChannelType === channelType.app) {
+      return this.appChannelBroadcastService;
     }
+  }
 
-    async broadcast(contextType, historyItem) {
+  //app channel broadcast service
+  appChannelBroadcastService = {
+    broadcast: async (contextType, historyItems, channel) => {
+      if (channel !== undefined) {
+        for (let i = 0; i < historyItems; i++) {
+          await channel.broadcast({
+            type: contextType,
+            name: `History-item-${i + 1}`,
+          });
+        }
+      }
+    },
+  };
+
+  //system channel broadcast service
+  systemChannelBroadcastService = {
+    broadcast: async (contextType, historyItems) => {
+      for (let i = 0; i < historyItems; i++) {
         await window.fdc3.broadcast({
-            "type": contextType,
-            "name": `History-item-${historyItem}`
+          type: contextType,
+          name: `History-item-${i + 1}`,
         });
-    }
+      }
+    },
+  };
 
-    async addContextListener(contextType) {
-        await window.fdc3.addContextListener(
-            contextType,
-            () => closeFinsembleWindow());
-    }
+  //close ChannelsApp on completion and respond to app A
+  async closeWindowOnCompletion() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    await appControlChannel.addContextListener("closeWindow", async () => {
+      window.close();
+      appControlChannel.broadcast({ type: "windowClosed" });
+    });
+  }
+
+  async notifyAppAOnCompletion() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    await this.broadcastContextItem("executionComplete", appControlChannel, 1);
+  }
+
+  async NotifyAppAOnWindowClose() {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    await this.broadcastContextItem("windowClosed", appControlChannel, 1);
+  }
 }
 
+const channelType = {
+  system: "system",
+  app: "app",
+};
+
+const commands = {
+  joinSystemChannelOne: "joinSystemChannelOne",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};

--- a/mock/channels/index.html
+++ b/mock/channels/index.html
@@ -15,68 +15,15 @@
   <script>
     onFdc3Ready().then(() => {
       let firedOnce = false;
-      const stats = document.getElementById("context");
-      let channelService;
 
-      async function runChannelServices(context) {
-        const channelType = context.useAppChannel ? "app" : "user";
-        channelService = getChannelService(channelType);
-        let channel;
-        switch (context.reverseMethodCallOrder) {
-          //Join channel, then broadcast items
-          case false:
-            channel = await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            await broadcastContextItems(context, channel);
-            break;
-
-          //Broadcast items, then join channel
-          case true:
-            await broadcastContextItems(context);
-            await channelService.joinChannel();
-            stats.innerHTML += `Joined ${channelType} channel/ `;
-            break;
-        }
-
-        //Add listener so app A can close down Channels app
-        channelService.addContextListener("closeWindow", channel);
-        if (context.broadcastExecutionComplete) {
-          //broadcast to let App A know Channels app has finished executing
-          channelService.broadcast("executionComplete", 1, channel);
-        }
-      }
-
-      async function broadcastContextItems(context, channel) {
-       const items = context.broadcastMultipleItems ? 2 : 1;
-        for (const contextType in context.contextBroadcasts) {
-          if (context.contextBroadcasts[contextType]) {
-            for (let i = 0; i < items; i++) {
-              const historyItem = i + 1;
-              await channelService.broadcast(`fdc3.${contextType}`, historyItem, channel);
-              stats.innerHTML += `Broadcast fdc3.${contextType} - History-item-${historyItem}/ `;
-            }
-          }
-        };
-      }
-
-      function getChannelService(channelType) {
-        switch (channelType) {
-          case "user":
-            return new UserChannelService();
-          case "app":
-            return new AppChannelService();
-          default:
-            stats.innerHTML += "Unrecognised channel type/ ";
-        }
-      }
-
-      //Retrieve context
+      //await commands from App A, then execute commands
       window.fdc3.addContextListener(
         "channelsAppContext",
         (context) => {
           if (firedOnce === false) {
             firedOnce = true;
-            runChannelServices(context);
+            const commandExecutor = new Fdc3CommandExecutor();
+            commandExecutor.executeCommands(context.commands, context.config);
           }
         });
     });

--- a/mock/general/index.html
+++ b/mock/general/index.html
@@ -1,39 +1,38 @@
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="index.css" />
-  </head>
-  <body>
-    <p>Conformance Framework Mock App</p>
-    <p>This app is only used by the conformance framework for test purposes.</p>
-    <p></p>
-    <p id="context"></p>
-    <script src="lib/mock-functions.js"></script>
-    <script>
-      onFdc3Ready().then(() => {
-        const stats = document.getElementById("context");
-  
-        window.fdc3.joinChannel("FDC3-Conformance-Channel").then(() => {
-          // broadcast that this app has opened
-          window.fdc3.broadcast({
-            type: "fdc3-conformance-opened",
-          });
-  
-          // Context listeners used by tests.
-          window.fdc3.addContextListener("fdc3.testReceiver", (context) => {
-            stats.innerHTML = `Received Data: ${JSON.stringify(context)}`;
-  
-            // broadcast that this app has received context
-            window.fdc3.broadcast({
-              type: "fdc3-conformance-context-received",
-              context: context,
-            });
-          });
-  
-          window.fdc3.addContextListener("fdc3.instrument");
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="index.css" />
+</head>
+
+<body>
+  <p>Conformance Framework Mock App</p>
+  <p>This app is only used by the conformance framework for test purposes.</p>
+  <p></p>
+  <script src="lib/mock-functions.js"></script>
+  <script type="module">
+    onFdc3Ready().then(() => {
+      window.fdc3.joinChannel("FDC3-Conformance-Channel").then(() => {
+        // broadcast that this app has opened
+        window.fdc3.broadcast({
+          type: "fdc3-conformance-opened",
         });
-        setupCloseListener(window.fdc3);
+
+        // Context listeners used by tests.
+        window.fdc3.addContextListener("fdc3.testReceiver", (context) => {
+
+          // broadcast that this app has received context
+          window.fdc3.broadcast({
+            type: "fdc3-conformance-context-received",
+            context: context,
+          });
+        });
+
+        window.fdc3.addContextListener("fdc3.instrument");
       });
-    </script>
-  </body>
+      closeWindowOnCompletion(window.fdc3);
+    });
+  </script>
+</body>
+
 </html>

--- a/mock/intent-a/index.html
+++ b/mock/intent-a/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App A</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener("aTestingIntent", (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -21,7 +21,7 @@
             type: "fdc3-intent-a-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/intent-b/index.html
+++ b/mock/intent-b/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App B</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener('bTestingIntent', (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -20,7 +20,7 @@
             type: "fdc3-intent-b-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/intent-c/index.html
+++ b/mock/intent-c/index.html
@@ -7,7 +7,7 @@
     <p>Conformance Framework Mock Intent App C</p>
     <p>This app is only used by the conformance framework for intent test purposes.</p>
     <script src="lib/mock-functions.js"></script>
-    <script>
+    <script type="module">
       onFdc3Ready().then(() => {
         window.fdc3.addIntentListener('cTestingIntent', (context) => {
           return new Promise<Context>((resolve) => resolve(context));
@@ -17,7 +17,7 @@
             type: "fdc3-intent-c-opened",
           });
         });
-        setupCloseListener(window.fdc3);
+        closeWindowOnCompletion(window.fdc3);
       });
     </script>
   </body>

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -6,20 +6,15 @@ const onFdc3Ready = () => new Promise((resolve) => {
     }
 });
 
-const setupCloseListener = async (fdc3) => {
-    const channel = await fdc3.getOrCreateChannel("fdc3.raiseIntent");
-    await channel.addContextListener("closeWindow", async (context) => {
-        // FDC3 application specific functions called here to close window
-        closeFinsembleWindow();
+const closeWindowOnCompletion = async (fdc3) => {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+        "app-control"
+      );
+    await appControlChannel.addContextListener("closeWindow", async (context) => {
+        window.close();
+
+        //notify app A that window was closed
+        await appControlChannel.broadcast({type: "windowClosed"});
     });
 };
 
-// https://documentation.finsemble.com/docs/smart-desktop/windows-and-workspaces/API-WindowClient/#close
-const closeFinsembleWindow = async () => {
-    if (FSBL) {
-        await FSBL.Clients.WindowClient.close({
-            removeFromWorkspace: false,
-            closeWindow: false
-        });
-    }
-};

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -4,7 +4,7 @@
 const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
-  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
+  WaitTime: 1500, // The amount of time to wait for mock apps to finish processing
 } as const;
 
 export default constants;

--- a/tests/src/test/fdc3.broadcast.ts
+++ b/tests/src/test/fdc3.broadcast.ts
@@ -1,28 +1,16 @@
-import { Listener, Channel, Context, ContextTypes } from "@finos/fdc3";
+import { Listener, Channel, Context, getCurrentChannel } from "@finos/fdc3";
 import { assert, expect } from "chai";
 import constants from "../constants";
-import fdc3AddContextListener from "./fdc3.addContextListener";
 import APIDocumentation from "../apiDocuments";
 
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
+let timeout: number;
 
 export default () =>
   describe("fdc3.broadcast", () => {
     let listener: Listener;
     let listener2: Listener;
-
-    let channelsAppContext = {
-      type: "channelsAppContext",
-      reverseMethodCallOrder: false,
-      contextBroadcasts: {
-        instrument: true,
-        contact: false,
-      },
-      useAppChannel: false,
-      broadcastMultipleItems: false,
-      broadcastExecutionComplete: false,
-    };
 
     it("Broadcast method is callable", async () => {
       await window.fdc3.broadcast({
@@ -31,38 +19,61 @@ export default () =>
       });
     });
 
-    describe("User channels", () => {
+    describe("System channels", () => {
       beforeEach(async () => {
         await unsubscribeListeners();
         await window.fdc3.leaveCurrentChannel();
-        resetChannelsAppContext();
       });
 
       afterEach(async () => {
-        await broadcastSystemChannelCloseWindow();
+        await closeChannelsAppWindow();
       });
 
       it("Should receive context when adding a listener then joining a user channel before app B broadcasts context to the same channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- Add fdc3.instrument context listener to app A\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
-            resolve();
-          });
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //Add context listener
+          listener = await window.fdc3.addContextListener(
+            null,
+            async (context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+              return;
+            }
+          );
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts context
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //if no context received throw error
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //reject if no context received
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -70,23 +81,47 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins channel 1\r\n- Add listener of type fdc3.instrument to App A\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //App A joins channel 1
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //Join system channel 1
           await joinChannel(1);
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
-            resolve();
-          });
+          //Add fdc3.instrument context listener
+          listener = await window.fdc3.addContextListener(
+            null,
+            async (context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+              return;
+            }
+          );
 
           validateListenerObject(listener);
 
-          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //if no context received throw error
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -94,23 +129,47 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          //Open ChannelsApp app. channels app joins channel 1, then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
-          //App A joins channel 1
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
+
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Join system channel 1
           await joinChannel(1);
 
-          //Add context listener to app A
-          listener = await window.fdc3.addContextListener(null, (context) => {
-            expect(context.type).to.be.equal("fdc3.instrument", errorMessage);
-            resolve();
-          });
+          //Add fdc3.instrument context listener
+          listener = await window.fdc3.addContextListener(
+            null,
+            async (context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+              return;
+            }
+          );
 
           validateListenerObject(listener);
 
-          //if no context received throw error
-          await wait();
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -118,9 +177,13 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.contextBroadcasts.contact = true;
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
-          //Add context listener to app A
+          //Add context listener
           listener = await window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -129,20 +192,33 @@ export default () =>
                 errorMessage
               );
               resolve();
+              return;
             }
           );
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           joinChannel(1);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
-          //if no context received throw error
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -150,10 +226,27 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
         return new Promise(async (resolve, reject) => {
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
           let contextTypes: string[] = [];
-          channelsAppContext.contextBroadcasts.contact = true;
+          function checkIfBothContextsReceived() {
+            if (contextTypes.length === 2) {
+              if (
+                !contextTypes.includes("fdc3.contact") ||
+                !contextTypes.includes("fdc3.instrument")
+              ) {
+                assert.fail("Incorrect context received", errorMessage);
+              } else {
+                resolve();
+                return;
+              }
+            }
+          }
 
-          //Add context listener to app A
+          //Add context listener
           listener = await window.fdc3.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -175,30 +268,29 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
-          function checkIfBothContextsReceived() {
-            if (contextTypes.length === 2) {
-              if (
-                !contextTypes.includes("fdc3.contact") ||
-                !contextTypes.includes("fdc3.instrument")
-              ) {
-                assert.fail("Incorrect context received", errorMessage);
-              } else {
-                resolve();
-              }
-            }
-          }
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
 
-          //if no context received throw error
-          await wait();
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Reject if no context received
           reject(
             new Error(`${errorMessage} At least one context was not received`)
           );
+          return;
         });
       });
 
@@ -206,38 +298,53 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.contextBroadcasts.contact = true;
-
-          //Add two context listeners to app A
+          //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
+          //Add fdc3.contact context listener
           listener2 = window.fdc3.addContextListener(
             "fdc3.contact",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener2);
 
-          //App A joins channel 2
+          //ChannelsApp joins channel 2
           await joinChannel(2);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
-          //give listener time to receive context
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands)
+          );
+
+          //Give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
 
@@ -245,27 +352,29 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A unsubscribes the listener\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.broadcastExecutionComplete = true;
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
 
-          //listens for when app B execution is complete
-          const executionCompleteContext =
-            executionCompleteListener("executionComplete");
-
-          //Add context listener
+          //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
-          //unsubscribe from listeners
+          //Unsubscribe from listeners
           if (listener !== undefined) {
             await listener.unsubscribe();
             listener = undefined;
@@ -273,11 +382,21 @@ export default () =>
             assert.fail("Listener undefined", errorMessage);
           }
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
-          await executionCompleteContext;
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
           resolve();
+          return;
         });
       });
 
@@ -285,32 +404,37 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.broadcastExecutionComplete = true;
-
-          //listens for when app B execution is complete
-          const executionCompleteContext =
-            executionCompleteListener("executionComplete");
-
-          //Add context listeners to app A
+          //Add fdc3.instrument context listener
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            async (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
-          validateListenerObject(listener);
-
-          //App A joins a channel and then joins another
+          //ChannelsApp joins a channel and then joins another
           await joinChannel(1);
           await joinChannel(2);
 
-          //Open ChannelsApp app. ChannelsApp joins channel 1, then broadcasts both contexts
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
-          await executionCompleteContext;
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands)
+          );
+
+          //Give listener time to receive context
+          await wait();
           resolve();
+          return;
         });
       });
 
@@ -321,26 +445,38 @@ export default () =>
           //Add a context listeners to app A
           listener = window.fdc3.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
-          //App A joins channel 1
+          //Join system channel 1
           await joinChannel(1);
 
           //App A leaves channel 1
           await window.fdc3.leaveCurrentChannel();
 
-          //App B joins channel 1, then broadcasts both contexts
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.joinSystemChannelOne,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //give listener time to receive context
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands)
+          );
+
+          //Give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
     });
@@ -349,87 +485,131 @@ export default () =>
       beforeEach(async () => {
         await unsubscribeListeners();
         await window.fdc3.leaveCurrentChannel();
-        resetChannelsAppContext();
       });
 
       afterEach(async () => {
-        await broadcastAppChannelCloseWindow();
+        await closeChannelsAppWindow();
       });
 
-      it("Should receive context when app B broadcasts the listened type to the same app channel", async () => {
+      it("Should receive context when app a adds a listener and app B broadcasts to the same app channel", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds adds a context listener of type null\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
-          listener = await testChannel.addContextListener(null, (context) => {
-            expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
-            resolve();
-          });
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //Add context listener
+          listener = await testChannel.addContextListener(
+            null,
+            async (context) => {
+              expect(context.type).to.be.equals(
+                "fdc3.instrument",
+                errorMessage
+              );
+              resolve();
+              return;
+            }
+          );
 
           validateListenerObject(listener);
 
-          //App B retrieves the same app channel as A then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //if no context received throw error
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
       it("Should receive context when app B broadcasts context to an app channel before A retrieves current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves the same app channel as B\r\n- App A retrieves current context of type null${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A & B retrieve the same app channel\r\n- App B broadcasts context of type fdc3.instrument\r\n- App A retrieves current context of type null${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-
-          //App B creates/retrieves an app channel then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
-
-          //give app B time to fully execute
-          await wait();
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+          ];
+
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands)
+          );
+
           //Retrieve current context from channel
-          await testChannel.getCurrentContext().then((context) => {
+          await testChannel.getCurrentContext().then(async (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
+            return;
           });
 
-          //if no context received throw error
-          await wait();
+          //Wait for ChannelsApp the finish executing
+          await resolveExecutionCompleteListener;
+
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
       it("Should receive context of correct type when app B broadcasts multiple contexts to an app channel before A retrieves current context of a specified type", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App B retrieves an app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retrieves the same app channel as B\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A & B retrieve the same app channel\r\n- App B broadcasts context of type fdc3.instrument and then of type fdc3.contact\r\n- App A retreives current context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-          channelsAppContext.contextBroadcasts.contact = true;
-
-          //App B creates/retrieves an app channel then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
-
-          //give app B time to fully execute
-          await wait();
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
+
+          //Listen for when AppChannel execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
+
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          await resolveExecutionCompleteListener;
 
           //Retrieve current context from channel
           await testChannel
@@ -440,11 +620,12 @@ export default () =>
                 errorMessage
               );
               resolve();
+              return;
             });
 
-          //if no context received throw error
-          await wait();
           reject(new Error(`${errorMessage} No context received`));
+          resolve();
+          return;
         });
       });
 
@@ -452,15 +633,18 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-          channelsAppContext.contextBroadcasts.contact = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //Add context listener
           listener = await testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -469,17 +653,30 @@ export default () =>
                 errorMessage
               );
               resolve();
+              return;
             }
           );
 
           validateListenerObject(listener);
 
-          //App B retrieves the same app channel as A then broadcasts two contexts
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
-          //if no context received throw error
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
@@ -488,15 +685,18 @@ export default () =>
 
         return new Promise(async (resolve, reject) => {
           let contextTypes: string[] = [];
-          channelsAppContext.useAppChannel = true;
-          channelsAppContext.contextBroadcasts.contact = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //Add context listener to app A
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //Add fdc3.instrument context listener
           listener = await testChannel.addContextListener(
             "fdc3.instrument",
             (context) => {
@@ -507,7 +707,7 @@ export default () =>
 
           validateListenerObject(listener);
 
-          //Add a second context listener to app A
+          //Add fdc3.contact context listener
           listener2 = await testChannel.addContextListener(
             "fdc3.contact",
             (context) => {
@@ -518,8 +718,17 @@ export default () =>
 
           validateListenerObject(listener2);
 
-          //App B retrieves the same app channel as A then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
+
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
 
           function checkIfBothContextsReceived() {
             if (contextTypes.length === 2) {
@@ -530,40 +739,41 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
+                return;
               }
             }
           }
 
-          //if no context received throw error
-          await wait();
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
+
+          //If no context received throw error
           reject(new Error(`${errorMessage} No context received`));
+          return;
         });
       });
 
-      it("Should not receive context when listening for all context types then unsubscribing an app channel before app B broadcasts to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
+      it("Should not receive context when unsubscribing an app channel before app B broadcasts to that channel", async () => {
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type null\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-          channelsAppContext.contextBroadcasts.contact = true;
-          channelsAppContext.broadcastExecutionComplete = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //listens for when app B execution is complete
-          const executionCompleteContext = executionCompleteListener(
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
             "executionComplete",
-            testChannel
+            await window.fdc3.getOrCreateChannel("app-control")
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(null, (context) => {
             reject(
               new Error(`${errorMessage} ${context.type} context received`)
             );
+            return;
           });
 
           validateListenerObject(listener);
@@ -571,50 +781,22 @@ export default () =>
           //Unsubscribe from app channel
           listener.unsubscribe();
 
-          //App B retrieves the same app channel as A then broadcasts context
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+            commands.broadcastContactContext,
+          ];
 
-          await executionCompleteContext;
-          resolve();
-        });
-      });
-
-      it("Should not receive context when unsubscribing an app channel before app B broadcasts the listened type to that channel", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App A unsubscribes the app channel\r\n- App B retrieves the same app channel as A\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact${documentation}`;
-
-        return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-          channelsAppContext.contextBroadcasts.contact = true;
-          channelsAppContext.broadcastExecutionComplete = true;
-
-          //App A retrieves app channel
-          const testChannel = await window.fdc3.getOrCreateChannel(
-            "test-channel"
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
           );
 
-          //listens for when app B execution is complete
-          const executionCompleteContext = executionCompleteListener(
-            "executionComplete",
-            testChannel
-          );
-
-          //Add context listener to app A
-          listener = testChannel.addContextListener(null, (context) => {
-            reject(
-              new Error(`${errorMessage} ${context.type} context received`)
-            );
-          });
-
-          validateListenerObject(listener);
-
-          //Unsubscribe from app channel
-          listener.unsubscribe();
-
-          //App B retrieves the same app channel as A then broadcasts context
-          window.fdc3.open("ChannelsApp", channelsAppContext);
-
-          await executionCompleteContext;
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
           resolve();
+          return;
         });
       });
 
@@ -622,30 +804,40 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           const testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              clearTimeout(timeout);
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
-          //App B retrieves the same app channel as A then broadcasts context
-          await window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //give listener time to receive context
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Give listener time to receive context
           await wait();
           resolve();
+          return;
         });
       });
 
@@ -653,123 +845,159 @@ export default () =>
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A switches to a different app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves the first channel that A retrieved\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         return new Promise(async (resolve, reject) => {
-          channelsAppContext.useAppChannel = true;
-
-          //App A retrieves app channel
+          //Retrieve an app channel
           let testChannel = await window.fdc3.getOrCreateChannel(
             "test-channel"
           );
 
-          //App A retrieves different app channel
+          //Listen for when ChannelsApp execution is complete
+          const resolveExecutionCompleteListener = waitForContext(
+            "executionComplete",
+            await window.fdc3.getOrCreateChannel("app-control")
+          );
+
+          //App A retrieves a different app channel
           testChannel = await window.fdc3.getOrCreateChannel(
             "a-different-test-channel"
           );
 
-          //Add context listener to app A
+          //Add context listener
           listener = testChannel.addContextListener(
             "fdc3.instrument",
-            (context) =>
+            (context) => {
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
-              )
+              );
+              return;
+            }
           );
 
           validateListenerObject(listener);
 
-          //App B retrieves the first channel that A retrieved then broadcasts context
-          window.fdc3.open("ChannelsApp", channelsAppContext);
+          const channelsAppCommands = [
+            commands.retrieveTestAppChannel,
+            commands.broadcastInstrumentContext,
+          ];
 
-          //give listener time to receive context
-          await wait();
+          //Open ChannelsApp then execute commands in order
+          await window.fdc3.open(
+            "ChannelsApp",
+            buildChannelsAppContext(channelsAppCommands, true)
+          );
+
+          //Wait for ChannelsApp to execute
+          await resolveExecutionCompleteListener;
           resolve();
+          return;
         });
       });
 
       it("Should receive both contexts when app B broadcasts both contexts to the same app channel and A gets current context for each type", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App A gets current context for types fdc3.instrument and fdc3.contact${documentation}`;
 
-        channelsAppContext.useAppChannel = true;
-        channelsAppContext.contextBroadcasts.contact = true;
-
-        //App A retrieves app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //App B retrieves the same app channel as A then broadcasts context
-        await window.fdc3.open("ChannelsApp", channelsAppContext);
+        const channelsAppCommands = [
+          commands.retrieveTestAppChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
-        //get contexts from app B
+        //Open ChannelsApp then execute commands in order
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(channelsAppCommands)
+        );
+
+        //get contexts from ChannelsApp
         const context = await testChannel.getCurrentContext("fdc3.instrument");
-
-        expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
-
+        expect(context.name).to.be.equals("History-item-1", errorMessage);
         const contactContext = await testChannel.getCurrentContext(
           "fdc3.contact"
         );
-
-        expect(contactContext.type).to.be.equals("fdc3.contact", errorMessage);
+        expect(contactContext.name).to.be.equals(
+          "History-item-1",
+          errorMessage
+        );
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts a context with multiple history items to the same app channel and A gets current context", async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts two different contexts of type fdc3.instrument\r\n- App A gets current context for types fdc3.instrument${documentation}`;
 
-        channelsAppContext.useAppChannel = true;
-        channelsAppContext.broadcastMultipleItems = true;
-
-        //App A retrieves app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //App B retrieves the same app channel as A then broadcasts context
-        await window.fdc3.open("ChannelsApp", channelsAppContext);
+        //Listen for when ChannelsApp execution is complete
+        const resolveExecutionCompleteListener = waitForContext(
+          "executionComplete",
+          await window.fdc3.getOrCreateChannel("app-control")
+        );
 
-        //Give app B time to execute
-        await wait();
+        const channelsAppCommands = [
+          commands.retrieveTestAppChannel,
+          commands.broadcastInstrumentContext,
+        ];
 
-        //get contexts from app B
+        //Open ChannelsApp and execute commands in order
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(channelsAppCommands, true, 2)
+        );
+
+        //Wait for ChannelsApp to execute
+        await resolveExecutionCompleteListener;
+
+        //Retrieve fdc3.instrument context
         const context = await testChannel.getCurrentContext("fdc3.instrument");
-
         expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
         expect(context.name).to.be.equals("History-item-2", errorMessage);
       });
 
       it("Should retrieve the last broadcast context item when app B broadcasts two different contexts to the same app channel and A gets current context", async () => {
-        const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins an app channel\r\n- App B joins the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
+        const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App B retrieves the same app channel\r\n- App B broadcasts a context of type fdc3.instrument and fdc3.contact\r\n- App B gets current context with no filter applied${documentation}`;
 
-        channelsAppContext.useAppChannel = true;
-        channelsAppContext.broadcastExecutionComplete = true;
-        channelsAppContext.contextBroadcasts.contact = true;
-
-        //App A retrieves app channel
+        //Retrieve an app channel
         const testChannel = await window.fdc3.getOrCreateChannel(
           "test-channel"
         );
 
-        //listens for when app B execution is complete
-        const executionCompleteContext = executionCompleteListener(
+        //Listen for when ChannelsApp execution is complete
+        const resolveExecutionCompleteListener = waitForContext(
           "executionComplete",
-          testChannel
+          await window.fdc3.getOrCreateChannel("app-control")
         );
 
-        //App B retrieves the same app channel as A then broadcasts context
-        await window.fdc3.open("ChannelsApp", channelsAppContext);
+        const channelsAppCommands = [
+          commands.retrieveTestAppChannel,
+          commands.broadcastInstrumentContext,
+          commands.broadcastContactContext,
+        ];
 
-        await executionCompleteContext;
+        //Open ChannelsApp then execute commands in order
+        await window.fdc3.open(
+          "ChannelsApp",
+          buildChannelsAppContext(channelsAppCommands, true)
+        );
 
-        //get current context
+        //Wait for ChannelsApp to execute
+        await resolveExecutionCompleteListener;
+
         const context = await testChannel.getCurrentContext();
 
         if (context === null) {
           assert.fail("No Context retrieved", errorMessage);
-        } else if (context.type === "closeWindow") {
+        } else if (context.type === "fdc3.instrument") {
           assert.fail(
             "Did not retrieve last broadcast context from app B",
             errorMessage
           );
         } else {
-          expect(context.type).to.be.equals("executionComplete", errorMessage);
+          expect(context.type).to.be.equals("fdc3.contact", errorMessage);
         }
       });
     });
@@ -792,22 +1020,27 @@ export default () =>
     }
 
     async function wait() {
-      return new Promise((resolve) =>
-        setTimeout(() => {
+      return new Promise((resolve) => {
+        timeout = window.setTimeout(() => {
           resolve(true);
-        }, constants.WaitTime)
-      );
+        }, constants.WaitTime);
+      });
     }
 
-    const broadcastSystemChannelCloseWindow = async () => {
-      await window.fdc3.broadcast({ type: "closeWindow" });
-      return new Promise<void>((resolve) => setTimeout(() => resolve(), 3000)); // Wait until close window event is handled
-    };
+    async function closeChannelsAppWindow() {
+      //Tell ChannelsApp to close window
+      const appControlChannel = await broadcastAppChannelCloseWindow();
+
+      //Wait for ChannelsApp to respond
+      await waitForContext("windowClosed", appControlChannel);
+    }
 
     const broadcastAppChannelCloseWindow = async () => {
-      const testChannel = await window.fdc3.getOrCreateChannel("test-channel");
-      await testChannel.broadcast({ type: "closeWindow" });
-      return new Promise<void>((resolve) => setTimeout(() => resolve(), 3000)); // Wait until close window event is handled
+      const appControlChannel = await window.fdc3.getOrCreateChannel(
+        "app-control"
+      );
+      await appControlChannel.broadcast({ type: "closeWindow" });
+      return appControlChannel;
     };
 
     async function unsubscribeListeners() {
@@ -822,18 +1055,7 @@ export default () =>
       }
     }
 
-    function resetChannelsAppContext() {
-      channelsAppContext.broadcastMultipleItems = false;
-      channelsAppContext.useAppChannel = false;
-      channelsAppContext.contextBroadcasts.contact = false;
-      channelsAppContext.reverseMethodCallOrder = false;
-      channelsAppContext.broadcastExecutionComplete = false;
-    }
-
-    const executionCompleteListener = (
-      contextType: string,
-      channel?: Channel
-    ) => {
+    const waitForContext = (contextType: string, channel?: Channel) => {
       return new Promise<Context>(async (resolve) => {
         if (channel === undefined) {
           const listener = await window.fdc3.addContextListener(
@@ -854,4 +1076,27 @@ export default () =>
         }
       });
     };
+
+    function buildChannelsAppContext(
+      mockAppCommands: string[],
+      notifyAppAOnCompletion?: boolean,
+      historyItems?: number
+    ) {
+      return {
+        type: "channelsAppContext",
+        commands: mockAppCommands,
+        config: {
+          notifyAppAOnCompletion: notifyAppAOnCompletion ?? false,
+          historyItems: historyItems ?? 1,
+        },
+      };
+    }
   });
+
+const commands = {
+  joinSystemChannelOne: "joinSystemChannelOne",
+  retrieveTestAppChannel: "retrieveTestAppChannel",
+  broadcastInstrumentContext: "broadcastInstrumentContext",
+  broadcastContactContext: "broadcastContactContext",
+};
+

--- a/tests/src/test/fdc3.open.ts
+++ b/tests/src/test/fdc3.open.ts
@@ -1,14 +1,17 @@
 import { OpenError, Context } from "@finos/fdc3";
+import { resolveObjectURL } from "buffer";
 import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
+import constants from "../constants";
 
 const appBName = "MockApp";
 const appBId = "MockAppId";
+let timeout: number;
 
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
 const createReceiver = (contextType: string) => {
-  const messageReceived = new Promise<Context>(async (resolve) => {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
     await window.fdc3.getOrCreateChannel("FDC3-Conformance-Channel");
     await window.fdc3.joinChannel("FDC3-Conformance-Channel");
 
@@ -16,13 +19,26 @@ const createReceiver = (contextType: string) => {
       contextType,
       (context) => {
         resolve(context);
+        clearTimeout(timeout);
         listener.unsubscribe();
       }
     );
+
+    //reject promise if no context received
+    await wait();
+    reject(new Error("No context received from app B"));
   });
 
   return messageReceived;
 };
+
+async function wait() {
+  return new Promise((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime);
+  });
+}
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation.open + "\r\nCause";
 
@@ -33,28 +49,19 @@ export default () =>
   describe("fdc3.open", () => {
     it("Can open app B from app A with no context and string as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open(appBName);
-
       await result;
     });
-
     it("Can open app B from app A with no context and AppMetadata (name) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open({ name: appBName });
-
       await result;
     });
-
     it("Can open app B from app A with no context and AppMetadata (name and appId) as target", async () => {
       const result = createReceiver("fdc3-conformance-opened");
-
       await window.fdc3.open({ name: appBName, appId: appBId });
-
       await result;
     });
-
     it("Receive AppNotFound error when targeting non-existent app name as target", async () => {
       try {
         await window.fdc3.open("ThisAppDoesNotExist");
@@ -63,7 +70,6 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Receive AppNotFound error when targeting non-existent app AppMetadata (name) as target", async () => {
       try {
         await window.fdc3.open({ name: "ThisAppDoesNotExist" });
@@ -72,7 +78,6 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Receive AppNotFound error when targeting non-existent app AppMetadata (name and appId) as target", async () => {
       try {
         await window.fdc3.open({
@@ -84,15 +89,12 @@ export default () =>
         expect(ex).to.have.property("message", OpenError.AppNotFound, openDocs);
       }
     });
-
     it("Can open app B from app A with context and AppMetadata (name) as target", async () => {
       const receiver = createReceiver("fdc3-conformance-context-received");
-
       await window.fdc3.open(
         { name: appBName },
         { name: "context", type: "fdc3.testReceiver" }
       );
-
       const receivedValue = (await receiver) as any;
       expect(receivedValue.context.name).to.eq("context", openDocs);
       expect(receivedValue.context.type).to.eq("fdc3.testReceiver", openDocs);

--- a/tests/src/test/fdc3.raiseIntent.ts
+++ b/tests/src/test/fdc3.raiseIntent.ts
@@ -1,5 +1,6 @@
 import {
   AppMetadata,
+  Channel,
   Context,
   IntentResolution,
   raiseIntent,
@@ -7,22 +8,9 @@ import {
 } from "@finos/fdc3";
 import { assert, expect } from "chai";
 import APIDocumentation from "../apiDocuments";
+import constants from "../constants";
 
-// creates a channel and subscribes for broadcast contexts. This is
-// used by the 'mock app' to send messages back to the test runner for validation
-const createReceiver = (contextType: string) => {
-  const messageReceived = new Promise<Context>(async (resolve) => {
-    const listener = await window.fdc3.addContextListener(
-      contextType,
-      (context) => {
-        resolve(context);
-        listener.unsubscribe();
-      }
-    );
-  });
-
-  return messageReceived;
-};
+let timeout: number;
 
 const raiseIntentDocs =
   "\r\nDocumentation: " + APIDocumentation.raiseIntent + "\r\nCause";
@@ -37,17 +25,9 @@ export default () =>
       await window.fdc3.joinChannel("fdc3.raiseIntent");
     });
 
-    const broadcastCloseWindow = async () => {
-      await window.fdc3.broadcast({ type: "closeWindow" });
-      return new Promise<void>((resolve) => setTimeout(() => resolve(), 1000)); // Wait until close window event is handled
-    };
-
-    beforeEach(async () => {
-      await broadcastCloseWindow();
-    });
-
     afterEach(async () => {
       await broadcastCloseWindow();
+      await waitForMockAppToClose();
     });
 
     it("Should start app intent-b when raising intent 'sharedTestingIntent1' with context 'testContextY'", async () => {
@@ -76,19 +56,6 @@ export default () =>
       await result;
     });
 
-    it("Should start app intent-a when targeted (name and appId) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
-      const result = createReceiver("fdc3-intent-a-opened");
-      const intentResolution = await window.fdc3.raiseIntent(
-        "aTestingIntent",
-        {
-          type: "testContextX",
-        },
-        { name: "IntentAppA", appId: "IntentAppAId" }
-      );
-      validateIntentResolution("IntentAppA", intentResolution);
-      await result;
-    });
-
     it("Should start app intent-a when targeted (name) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
       const result = createReceiver("fdc3-intent-a-opened");
       const intentResolution = await window.fdc3.raiseIntent(
@@ -99,6 +66,19 @@ export default () =>
         { name: "IntentAppA" }
       );
 
+      validateIntentResolution("IntentAppA", intentResolution);
+      await result;
+    });
+
+    it("Should start app intent-a when targeted (name and appId) by raising intent 'aTestingIntent' with context 'testContextX'", async () => {
+      const result = createReceiver("fdc3-intent-a-opened");
+      const intentResolution = await window.fdc3.raiseIntent(
+        "aTestingIntent",
+        {
+          type: "testContextX",
+        },
+        { name: "IntentAppA", appId: "IntentAppAId" }
+      );
       validateIntentResolution("IntentAppA", intentResolution);
       await result;
     });
@@ -115,6 +95,11 @@ export default () =>
         assert.fail("Error was not thrown");
       } catch (ex) {
         expect(ex).to.have.property("message", ResolveError.NoAppsFound);
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -134,6 +119,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -153,6 +143,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
 
@@ -172,6 +167,11 @@ export default () =>
           ResolveError.NoAppsFound,
           raiseIntentDocs
         );
+
+        //raise intent so that afterEach resolves
+        await window.fdc3.raiseIntent("sharedTestingIntent1", {
+          type: "testContextY",
+        });
       }
     });
   });
@@ -189,3 +189,59 @@ const validateIntentResolution = (
     );
   } else assert.fail("Invalid intent resolution object");
 };
+
+async function wait() {
+  return new Promise((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve(true);
+    }, constants.WaitTime);
+  });
+}
+
+const broadcastCloseWindow = async () => {
+  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+  await appControlChannel.broadcast({ type: "closeWindow" });
+};
+
+// creates a channel and subscribes for broadcast contexts. This is
+// used by the 'mock app' to send messages back to the test runner for validation
+const createReceiver = (contextType: string) => {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    const listener = await window.fdc3.addContextListener(
+      contextType,
+      (context) => {
+        resolve(context);
+        clearTimeout(timeout);
+        listener.unsubscribe();
+      }
+    );
+
+    //if no context received reject promise
+    await wait();
+    reject(new Error("No context received from app B"));
+  });
+
+  return messageReceived;
+};
+
+async function waitForMockAppToClose() {
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    const appControlChannel = await window.fdc3.getOrCreateChannel(
+      "app-control"
+    );
+    const listener = await appControlChannel.addContextListener(
+      "windowClosed",
+      (context) => {
+        resolve(context);
+        clearTimeout(timeout);
+        listener.unsubscribe();
+      }
+    );
+
+    //if no context received reject promise
+    await wait();
+    reject(new Error("windowClosed context not received from app B"));
+  });
+
+  return messageReceived;
+}


### PR DESCRIPTION
Recreating @Joe-Dunleavy's PR via a branch on FINOS repo (so it can be contributed to): 
- #78

resolves #72 
resolves #83

also addresses some of the feedback in #73

Original PR desccription:

> This is a pull request that addresses the following points from issue https://github.com/finos/FDC3-conformance-framework/issues/74:
> 
> -3) Some tests are hard to grok:
> 
> Much of the Channel tests' code has been refactored for improved test readability and efficiency.
> 
> -4) Wait times and total runtime:
> 
> Timeouts now get cancelled if the promise above resolves first.
> Removed wait times wherever possible.
> Overall runtime speed is much faster.
> 
> -5) Window closing:
> 
> The timeout that waits for the window to close should have been removed and was left there by mistake. This has now been fixed for all tests.
> All tests now use window.close to close the mock app windows
> 
> This pull request also addresses issue https://github.com/finos/FDC3-conformance-framework/issues/83:
> 
> All messaging between apps related to closing app windows and checking if execution has been completed is now done over a single dedicated app channel named "app-control"

Additional changes:
- Augmented control messages for the channel mocks with a testId field carrying the current test's name. This resolves race conditions in the revised approach where apps may miss control messages if sent too early, or if overlapping with the previous test.
- disabled caching on the dev servers
