### PR TITLE
Fix object assertions

### DIFF
--- a/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
@@ -1058,7 +1058,7 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isTrue(typeof listenerObject === "object", "No listener object found");
+      assert.isTrue(listenerObject && typeof listenerObject === "object", "No listener object found");
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"

--- a/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
@@ -1058,7 +1058,7 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isObject(listenerObject, "No listener object found");
+      assert.isTrue(typeof listenerObject === "object", "No listener object found");
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"

--- a/tests/src/test/v1.2/basic/fdc3.addContextListener.ts
+++ b/tests/src/test/v1.2/basic/fdc3.addContextListener.ts
@@ -34,7 +34,7 @@ export default () =>
     it("(BasicCL2) Returns listener object", async () => {
       try {
         listener = fdc3.addContextListener(null, () => {});
-        assert.isTrue(typeof listener === "object", documentation);
+        assert.isTrue(listener && typeof listener === "object", documentation);
         expect(typeof listener.unsubscribe, documentation).to.be.equals(
           "function"
         );

--- a/tests/src/test/v1.2/basic/fdc3.addContextListener.ts
+++ b/tests/src/test/v1.2/basic/fdc3.addContextListener.ts
@@ -34,7 +34,7 @@ export default () =>
     it("(BasicCL2) Returns listener object", async () => {
       try {
         listener = fdc3.addContextListener(null, () => {});
-        assert.isObject(listener, documentation);
+        assert.isTrue(typeof listener === "object", documentation);
         expect(typeof listener.unsubscribe, documentation).to.be.equals(
           "function"
         );

--- a/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
@@ -1507,7 +1507,7 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isTrue(typeof listenerObject === "object", "No listener object found");
+      assert.isTrue(listenerObject && typeof listenerObject === "object", "No listener object found");
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"

--- a/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
@@ -1507,7 +1507,7 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isObject(listenerObject, "No listener object found");
+      assert.isTrue(typeof listenerObject === "object", "No listener object found");
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"


### PR DESCRIPTION
We've bit an issue with the `Assert.isObject` assertion used to validate listeners - as per the assertions docs it does not return true for subclassed objects, which we use in our 2.0 implementation - where a simpler `typeof` based check is fine (in fact in most places this check is redundant as the next check is to look for a property of the object, e.g. listener.unsubscribe).

This PR swaps out the assertion for typeof based check and an Assert.isTrue assertion.