### PR TITLE
Fix antipatterns and local timer code

### DIFF
--- a/mock/intent-a/index.html
+++ b/mock/intent-a/index.html
@@ -9,11 +9,11 @@
     <script src="lib/mock-functions.js"></script>
     <script type="module">
       onFdc3Ready().then(() => {
-        window.fdc3.addIntentListener("aTestingIntent", (context) => {
-          return new Promise<Context>((resolve) => resolve(context));
+        window.fdc3.addIntentListener("aTestingIntent", async (context) => {
+          return context;
         });
-        window.fdc3.addIntentListener("sharedTestingIntent1", (context) => {
-          return new Promise<Context>((resolve) => resolve(context));
+        window.fdc3.addIntentListener("sharedTestingIntent1", async (context) => {
+          return context;
         });
   
         window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {

--- a/mock/intent-b/index.html
+++ b/mock/intent-b/index.html
@@ -9,11 +9,11 @@
     <script src="lib/mock-functions.js"></script>
     <script type="module">
       onFdc3Ready().then(() => {
-        window.fdc3.addIntentListener('bTestingIntent', (context) => {
-          return new Promise<Context>((resolve) => resolve(context));
+        window.fdc3.addIntentListener('bTestingIntent', async (context) => {
+          return context;
         });
-        window.fdc3.addIntentListener('sharedTestingIntent1', (context) => {
-          return new Promise<Context>((resolve) => resolve(context));
+        window.fdc3.addIntentListener('sharedTestingIntent1', async (context) => {
+          return context;
         });
         window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
           window.fdc3.broadcast({

--- a/mock/intent-c/index.html
+++ b/mock/intent-c/index.html
@@ -9,8 +9,8 @@
     <script src="lib/mock-functions.js"></script>
     <script type="module">
       onFdc3Ready().then(() => {
-        window.fdc3.addIntentListener('cTestingIntent', (context) => {
-          return new Promise<Context>((resolve) => resolve(context));
+        window.fdc3.addIntentListener('cTestingIntent', async (context) => {
+          return context;
         });
         window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
           window.fdc3.broadcast({

--- a/tests/src/constants.ts
+++ b/tests/src/constants.ts
@@ -5,6 +5,7 @@ const constants = {
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
   WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
+  WindowCloseWaitTime: 100, // The amount of time to allow for clean-up of closed windows
 } as const;
 
 export default constants;

--- a/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v1.2/advanced/fdc3.broadcast.ts
@@ -3,12 +3,12 @@ import { assert, expect } from "chai";
 import constants from "../../../constants";
 import APIDocumentation from "../../../apiDocuments";
 import { DesktopAgent } from "fdc3_1_2/dist/api/DesktopAgent";
+import { sleep, wait } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
-let timeout: number;
 
 interface AppControlContext extends Context {
   testId: string;
@@ -355,7 +355,7 @@ export default () =>
         );
 
         //Give listeners time to receive context
-        wait();
+        await wait();
       });
 
       const scTestId7 =
@@ -1058,19 +1058,14 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isTrue(typeof listenerObject === "object", "No listener object found");
+      assert.isTrue(
+        typeof listenerObject === "object",
+        "No listener object found"
+      );
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"
       );
-    }
-
-    async function wait() {
-      return new Promise((resolve) => {
-        timeout = window.setTimeout(() => {
-          resolve(true);
-        }, constants.WaitTime);
-      });
     }
 
     async function closeChannelsAppWindow(testId: string) {
@@ -1079,6 +1074,7 @@ export default () =>
 
       //Wait for ChannelsApp to respond
       await waitForContext("windowClosed", testId, appControlChannel);
+      await wait(constants.WindowCloseWaitTime);
     }
 
     const broadcastAppChannelCloseWindow = async (testId: string) => {

--- a/tests/src/test/v1.2/advanced/fdc3.open.ts
+++ b/tests/src/test/v1.2/advanced/fdc3.open.ts
@@ -3,6 +3,7 @@ import { assert, expect } from "chai";
 import APIDocumentation from "../../../apiDocuments";
 import constants from "../../../constants";
 import { DesktopAgent } from "fdc3_1_2/dist/api/DesktopAgent";
+import { sleep, wait } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 const appBName = "MockApp";
@@ -11,7 +12,6 @@ const noListenerAppId = "IntentAppAId";
 const noListenerAppName = "IntentAppA";
 const genericListenerAppId = "IntentAppBId";
 const genericListenerAppName = "IntentAppB";
-let timeout: number;
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation.open + "\r\nCause";
 
@@ -235,6 +235,7 @@ export default () =>
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
 const createReceiver = (contextType: string) => {
+  let timeout;
   const messageReceived = new Promise<Context>(async (resolve, reject) => {
     const listener = fdc3.addContextListener(contextType, (context) => {
       resolve(context);
@@ -243,7 +244,9 @@ const createReceiver = (contextType: string) => {
     });
 
     //if no context received reject promise
-    await wait();
+    const { promise: thePromise, timeout: theTimeout } = sleep();
+    timeout = theTimeout;
+    await thePromise;
     reject(new Error("No context received from app B"));
   });
 
@@ -254,6 +257,7 @@ async function closeAppWindows(testId) {
   await broadcastCloseWindow(testId);
   const appControlChannel = await fdc3.getOrCreateChannel("app-control");
   await waitForContext("windowClosed", testId, appControlChannel);
+  await wait(constants.WindowCloseWaitTime);
 }
 
 const broadcastCloseWindow = async (currentTest) => {
@@ -346,14 +350,6 @@ const waitForContext = (
     }
   });
 };
-
-async function wait() {
-  return new Promise((resolve) => {
-    timeout = window.setTimeout(() => {
-      resolve(true);
-    }, constants.WaitTime);
-  });
-}
 
 interface AppControlContext extends Context {
   testId: string;

--- a/tests/src/test/v1.2/advanced/fdc3.raiseIntent.ts
+++ b/tests/src/test/v1.2/advanced/fdc3.raiseIntent.ts
@@ -10,9 +10,9 @@ import { assert, expect } from "chai";
 import APIDocumentation from "../../../apiDocuments";
 import constants from "../../../constants";
 import { DesktopAgent } from "fdc3_1_2/dist/api/DesktopAgent";
+import { sleep, wait } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
-let timeout: number;
 
 const raiseIntentDocs =
   "\r\nDocumentation: " + APIDocumentation.raiseIntent + "\r\nCause";
@@ -204,14 +204,6 @@ const validateIntentResolution = (
   } else assert.fail("Invalid intent resolution object");
 };
 
-async function wait() {
-  return new Promise((resolve) => {
-    timeout = window.setTimeout(() => {
-      resolve(true);
-    }, constants.WaitTime);
-  });
-}
-
 const broadcastCloseWindow = async (currentTest) => {
   const appControlChannel = await fdc3.getOrCreateChannel("app-control");
   appControlChannel.broadcast({
@@ -223,6 +215,7 @@ const broadcastCloseWindow = async (currentTest) => {
 // creates a channel and subscribes for broadcast contexts. This is
 // used by the 'mock app' to send messages back to the test runner for validation
 const createReceiver = (contextType: string) => {
+  let timeout;
   const messageReceived = new Promise<Context>(async (resolve, reject) => {
     const listener = fdc3.addContextListener(contextType, (context) => {
       resolve(context);
@@ -231,7 +224,9 @@ const createReceiver = (contextType: string) => {
     });
 
     //if no context received reject promise
-    await wait();
+    const { promise: sleepPromise, timeout: theTimeout } = sleep();
+    timeout = theTimeout;
+    await sleepPromise;
     reject(new Error("No context received from app B"));
   });
 
@@ -242,6 +237,7 @@ async function closeIntentAppsWindows(testId) {
   await broadcastCloseWindow(testId);
   const appControlChannel = await fdc3.getOrCreateChannel("app-control");
   await waitForContext("windowClosed", testId, appControlChannel);
+  await wait(constants.WindowCloseWaitTime);
 }
 
 const waitForContext = (

--- a/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
+++ b/tests/src/test/v2.0/advanced/fdc3.broadcast.ts
@@ -3,11 +3,11 @@ import { assert, expect } from "chai";
 import constants from "../../../constants";
 import APIDocumentation from "../../../apiDocuments";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
+import { sleep, wait } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 const documentation =
   "\r\nDocumentation: " + APIDocumentation.desktopAgent + "\r\nCause:";
-let timeout: number;
 
 interface AppControlContext extends Context {
   testId: string;
@@ -53,7 +53,6 @@ export default () =>
           listener = await fdc3.addContextListener(null, async (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
-            return;
           });
 
           validateListenerObject(listener);
@@ -83,7 +82,6 @@ export default () =>
 
           //reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -107,7 +105,6 @@ export default () =>
           listener = await fdc3.addContextListener(null, async (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
-            return;
           });
 
           validateListenerObject(listener);
@@ -134,7 +131,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -175,7 +171,6 @@ export default () =>
           listener = await fdc3.addContextListener(null, async (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
-            return;
           });
 
           validateListenerObject(listener);
@@ -185,7 +180,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -211,7 +205,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -243,7 +236,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -272,7 +264,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -301,7 +292,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -348,7 +338,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -359,7 +348,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -409,7 +397,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -417,7 +404,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -444,7 +430,6 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
-                return;
               }
             }
           }
@@ -499,7 +484,6 @@ export default () =>
           reject(
             new Error(`${errorMessage} At least one context was not received`)
           );
-          return;
         });
       });
 
@@ -507,7 +491,7 @@ export default () =>
         "Should not receive context when A & B join different user channels and app B broadcasts a listened type";
       it(scTestId9, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
-
+        let timeout;
         return new Promise(async (resolve, reject) => {
           //Add fdc3.instrument context listener
           listener = await fdc3.addContextListener(
@@ -517,7 +501,6 @@ export default () =>
                 new Error(`${errorMessage} ${context.type} context received`)
               );
               clearTimeout(timeout);
-              return;
             }
           );
 
@@ -531,7 +514,6 @@ export default () =>
                 new Error(`${errorMessage} ${context.type} context received`)
               );
               clearTimeout(timeout);
-              return;
             }
           );
 
@@ -558,9 +540,10 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await wait();
+          const { promise: sleepPromise, timeout: theTimeout } = sleep();
+          timeout = theTimeout;
+          await sleepPromise;
           resolve();
-          return;
         });
       });
 
@@ -584,7 +567,6 @@ export default () =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
               );
-              return;
             }
           );
 
@@ -621,7 +603,6 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
           resolve();
-          return;
         });
       });
 
@@ -629,7 +610,7 @@ export default () =>
         "Should not receive context when joining two different user channels before app B broadcasts the listened type to the first channel that was joined";
       it(scTestId11, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
-
+        let timeout;
         return new Promise(async (resolve, reject) => {
           //Add fdc3.instrument context listener
           listener = await fdc3.addContextListener(
@@ -639,7 +620,6 @@ export default () =>
                 new Error(`${errorMessage} ${context.type} context received`)
               );
               clearTimeout(timeout);
-              return;
             }
           );
 
@@ -664,9 +644,10 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await wait();
+          const { promise: sleepPromise, timeout: theTimeout } = sleep();
+          timeout = theTimeout;
+          await sleepPromise;
           resolve();
-          return;
         });
       });
 
@@ -674,7 +655,7 @@ export default () =>
         "Should not receive context when joining and then leaving a user channel before app B broadcasts the listened type to the same channel";
       it(scTestId12, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A leaves channel 1\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
-
+        let timeout;
         return new Promise(async (resolve, reject) => {
           //Add a context listeners to app A
           listener = await fdc3.addContextListener(
@@ -684,7 +665,6 @@ export default () =>
                 new Error(`${errorMessage} ${context.type} context received`)
               );
               clearTimeout(timeout);
-              return;
             }
           );
 
@@ -714,9 +694,10 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await wait();
+          const { promise: sleepPromise, timeout: theTimeout } = sleep();
+          timeout = theTimeout;
+          await sleepPromise;
           resolve();
-          return;
         });
       });
 
@@ -776,7 +757,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -804,7 +784,6 @@ export default () =>
 
           //Reject if no context received
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -845,14 +824,12 @@ export default () =>
           await testChannel.getCurrentContext().then(async (context) => {
             expect(context.type).to.be.equals("fdc3.instrument", errorMessage);
             resolve();
-            return;
           });
 
           //Wait for ChannelsApp the finish executing
           await resolveExecutionCompleteListener;
 
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -901,12 +878,10 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             });
 
           reject(new Error(`${errorMessage} No context received`));
           resolve();
-          return;
         });
       });
 
@@ -935,7 +910,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -964,7 +938,6 @@ export default () =>
 
           //If no context received throw error
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -1034,7 +1007,6 @@ export default () =>
                 assert.fail("Incorrect context received", errorMessage);
               } else {
                 resolve();
-                return;
               }
             }
           }
@@ -1044,7 +1016,6 @@ export default () =>
 
           //If no context received throw error
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -1069,7 +1040,6 @@ export default () =>
             reject(
               new Error(`${errorMessage} ${context.type} context received`)
             );
-            return;
           });
 
           validateListenerObject(listener);
@@ -1098,7 +1068,6 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
           resolve();
-          return;
         });
       });
 
@@ -1106,7 +1075,7 @@ export default () =>
         "Should not receive context when app B broadcasts context to a different app channel";
       it(acTestId7, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
-
+        let timeout;
         return new Promise(async (resolve, reject) => {
           //Retrieve an app channel
           const testChannel = await fdc3.getOrCreateChannel(
@@ -1121,7 +1090,6 @@ export default () =>
                 new Error(`${errorMessage} ${context.type} context received`)
               );
               clearTimeout(timeout);
-              return;
             }
           );
 
@@ -1144,9 +1112,10 @@ export default () =>
           );
 
           //Give listener time to receive context
-          await wait();
+          const { promise: sleepPromise, timeout: theTimeout } = sleep();
+          timeout = theTimeout;
+          await sleepPromise;
           resolve();
-          return;
         });
       });
 
@@ -1195,12 +1164,10 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             });
 
           reject(new Error(`${errorMessage} No context received`));
           resolve();
-          return;
         });
       });
 
@@ -1229,7 +1196,6 @@ export default () =>
                 errorMessage
               );
               resolve();
-              return;
             }
           );
 
@@ -1247,7 +1213,6 @@ export default () =>
                   `${errorMessage} fdc3.instrument context received on the second channel that was joined rather than the first`
                 )
               );
-              return;
             }
           );
 
@@ -1276,7 +1241,6 @@ export default () =>
 
           //If no context received throw error
           reject(new Error(`${errorMessage} No context received`));
-          return;
         });
       });
 
@@ -1308,7 +1272,6 @@ export default () =>
               reject(
                 new Error(`${errorMessage} ${context.type} context received`)
               );
-              return;
             }
           );
 
@@ -1334,7 +1297,6 @@ export default () =>
           //Wait for ChannelsApp to execute
           await resolveExecutionCompleteListener;
           resolve();
-          return;
         });
       });
 
@@ -1507,19 +1469,14 @@ export default () =>
     };
 
     function validateListenerObject(listenerObject) {
-      assert.isTrue(typeof listenerObject === "object", "No listener object found");
+      assert.isTrue(
+        typeof listenerObject === "object",
+        "No listener object found"
+      );
       expect(typeof listenerObject.unsubscribe).to.be.equals(
         "function",
         "Listener does not contain an unsubscribe method"
       );
-    }
-
-    async function wait() {
-      return new Promise((resolve) => {
-        timeout = window.setTimeout(() => {
-          resolve(true);
-        }, constants.WaitTime);
-      });
     }
 
     async function closeChannelsAppWindow(testId: string) {
@@ -1528,6 +1485,7 @@ export default () =>
 
       //Wait for ChannelsApp to respond
       await waitForContext("windowClosed", testId, appControlChannel);
+      await wait(constants.WindowCloseWaitTime);
     }
 
     const broadcastAppChannelCloseWindow = async (testId: string) => {

--- a/tests/src/test/v2.0/advanced/fdc3.findInstances.ts
+++ b/tests/src/test/v2.0/advanced/fdc3.findInstances.ts
@@ -3,7 +3,7 @@ import APIDocumentation from "../../../apiDocuments";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { Context } from "fdc3_2_0";
 import constants from "../../../constants";
-import { sleep } from "../../../utils";
+import { sleep, wait } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 const findInstancesDocs =
@@ -69,7 +69,7 @@ export default () =>
           appIdentifier
         );
 
-        const { promise: sleepPromise, timeout: theTimeout } = sleep();
+        const {promise: sleepPromise, timeout: theTimeout} = sleep();
         timeout = theTimeout;
         await sleepPromise;
         if (!listenerReceived)
@@ -86,14 +86,15 @@ async function waitForMockAppToClose() {
     const appControlChannel = await fdc3.getOrCreateChannel("app-control");
     const listener = await appControlChannel.addContextListener(
       "windowClosed",
-      (context) => {
+      async (context) => {
+        await wait(constants.WindowCloseWaitTime);
         resolve(context);
         listener.unsubscribe();
       }
     );
 
     //if no context received reject promise
-    const { promise: sleepPromise, timeout: theTimeout } = sleep();
+    const {promise: sleepPromise, timeout: theTimeout} = sleep();
     timeout = theTimeout;
     await sleepPromise;
     reject(new Error("windowClosed context not received from app B"));

--- a/tests/src/test/v2.0/advanced/fdc3.getAppMetadata.ts
+++ b/tests/src/test/v2.0/advanced/fdc3.getAppMetadata.ts
@@ -3,12 +3,12 @@ import APIDocumentation from "../../../apiDocuments";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { Context } from "fdc3_2_0";
 import constants from "../../../constants";
+import { sleep } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 
 const getMetadataDocs =
   "\r\nDocumentation: " + APIDocumentation.appMetadata + "\r\nCause";
-let timeout: number;
 
 export default () =>
   describe("fdc3.getAppMetadata", () => {
@@ -102,6 +102,7 @@ export default () =>
   });
 
 async function waitForMockAppToClose() {
+  let timeout;
   const messageReceived = new Promise<Context>(async (resolve, reject) => {
     const appControlChannel = await fdc3.getOrCreateChannel("app-control");
     const listener = await appControlChannel.addContextListener(
@@ -114,7 +115,9 @@ async function waitForMockAppToClose() {
     );
 
     //if no context received reject promise
-    await wait();
+    const {promise: sleepPromise, timeout: theTimeout} = sleep();
+    timeout = theTimeout;
+    await sleepPromise;
     reject(new Error("windowClosed context not received from app B"));
   });
 
@@ -196,10 +199,3 @@ const broadcastCloseWindow = async () => {
   await appControlChannel.broadcast({ type: "closeWindow" });
 };
 
-async function wait() {
-  return new Promise((resolve) => {
-    timeout = window.setTimeout(() => {
-      resolve(true);
-    }, constants.WaitTime);
-  });
-}

--- a/tests/src/test/v2.0/basic/fdc3.getInfo.ts
+++ b/tests/src/test/v2.0/basic/fdc3.getInfo.ts
@@ -4,13 +4,13 @@ import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { Context } from "fdc3_2_0";
 import constants from "../../../constants";
 import { validateAppMetadata } from "../advanced/fdc3.getAppMetadata";
+import { sleep } from "../../../utils";
 
 const fdc3 = <DesktopAgent>(<unknown>window.fdc3);
 const getInfoDocs =
   "\r\nDocumentation: " + APIDocumentation.getInfo2_0 + "\r\nCause";
 const getMetadataDocs =
   "\r\nDocumentation: " + APIDocumentation.appMetadata + "\r\nCause";
-let timeout: number;
 
 export default () =>
   describe("fdc3.getInfo", () => {
@@ -87,6 +87,7 @@ export default () =>
     });
 
     async function waitForMockAppToClose() {
+      let timeout;
       const messageReceived = new Promise<Context>(async (resolve, reject) => {
         const appControlChannel = await fdc3.getOrCreateChannel("app-control");
         const listener = await appControlChannel.addContextListener(
@@ -99,7 +100,9 @@ export default () =>
         );
 
         //if no context received reject promise
-        await wait();
+        const {promise: sleepPromise, timeout: theTimeout} = sleep();
+        timeout = theTimeout;
+        await sleepPromise;
         reject(new Error("windowClosed context not received from app B"));
       });
 
@@ -111,11 +114,4 @@ export default () =>
       await appControlChannel.broadcast({ type: "closeWindow" });
     };
 
-    async function wait() {
-      return new Promise((resolve) => {
-        timeout = window.setTimeout(() => {
-          resolve(true);
-        }, constants.WaitTime);
-      });
-    }
   });

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -1,0 +1,16 @@
+import constants from "./constants";
+
+export function sleep(timeoutMs: number = constants.WaitTime) {
+  let timeout;
+  const promise = new Promise<void>((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve();
+    }, timeoutMs);
+  });
+  return { promise, timeout };
+}
+
+export async function wait(timeoutMs?: number): Promise<void> {
+  const { promise, timeout } = sleep(timeoutMs);
+  return promise;
+}


### PR DESCRIPTION
While testing, we had a very occasional failure in raiseIntent tests caused by a race between window closing and test execution. This is fixed by adding a small wait time after each window close.

While making that change we applied a few other code improvements:
- Moved duplicated wait functions to a util file so that they are not redefined in every test,
- Made timeouts local to functions that use them to avoid clashes between them/accidental overwrites or clears, 
- Removed redundant return statements from event handlers (noop if last statement in the function)
- Removed Promise constructor where not needed (antipattern, just use the async keyword)
- Added short wait times on window close to reduce chance or race conditions in tests/unstable results.

There are likely other re-used functions that could move to the util file... however, we haven't yet looked for those (and think it likely that they may vary between tests).