### PR TITLE
When closing mock app windows, await fdc3 api calls/or not depending on the version retrieved

### DIFF
--- a/mock/general/index.html
+++ b/mock/general/index.html
@@ -27,10 +27,7 @@
             context: context,
           });
         });
-
-        window.fdc3.addContextListener("fdc3.instrument");
       });
-      
     });
   </script>
 </body>

--- a/mock/general/index.html
+++ b/mock/general/index.html
@@ -11,7 +11,7 @@
   <script src="lib/mock-functions.js"></script>
   <script type="module">
     onFdc3Ready().then( async() => {
-      await closeWindowOnCompletion(window.fdc3);
+      await closeWindowOnCompletion();
       window.fdc3.joinChannel("FDC3-Conformance-Channel").then(() => {
         // broadcast that this app has opened
         window.fdc3.broadcast({

--- a/mock/intent-a/index.html
+++ b/mock/intent-a/index.html
@@ -11,7 +11,7 @@
   <script src="lib/mock-functions.js"></script>
   <script type="module">
     onFdc3Ready().then(async () => {
-      await closeWindowOnCompletion(window.fdc3);
+      await closeWindowOnCompletion();
       window.fdc3.addIntentListener("aTestingIntent", async (context) => {
         return context;
       });

--- a/mock/intent-a/index.html
+++ b/mock/intent-a/index.html
@@ -1,28 +1,31 @@
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="index.css" />
-  </head>
-  <body>
-    <p>Conformance Framework Mock Intent App A</p>
-    <p>This app is only used by the conformance framework for intent test purposes.</p>
-    <script src="lib/mock-functions.js"></script>
-    <script type="module">
-      onFdc3Ready().then(async () => {
-        await closeWindowOnCompletion(window.fdc3);
-        window.fdc3.addIntentListener("aTestingIntent", async (context) => {
-          return context;
-        });
-        window.fdc3.addIntentListener("sharedTestingIntent1", async (context) => {
-          return context;
-        });
-  
-        window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
-          window.fdc3.broadcast({
-            type: "fdc3-intent-a-opened",
-          });
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="index.css" />
+</head>
+
+<body>
+  <p>Conformance Framework Mock Intent App A</p>
+  <p>This app is only used by the conformance framework for intent test purposes.</p>
+  <script src="lib/mock-functions.js"></script>
+  <script type="module">
+    onFdc3Ready().then(async () => {
+      await closeWindowOnCompletion(window.fdc3);
+      window.fdc3.addIntentListener("aTestingIntent", async (context) => {
+        return context;
+      });
+      window.fdc3.addIntentListener("sharedTestingIntent1", async (context) => {
+        return context;
+      });
+
+      window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
+        window.fdc3.broadcast({
+          type: "fdc3-intent-a-opened",
         });
       });
-    </script>
-  </body>
+    });
+  </script>
+</body>
+
 </html>

--- a/mock/intent-b/index.html
+++ b/mock/intent-b/index.html
@@ -1,23 +1,25 @@
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="index.css" />
 </head>
+
 <body>
   <p>Conformance Framework Mock Intent App B</p>
   <p>This app is only used by the conformance framework for intent test purposes.</p>
   <script src="lib/mock-functions.js"></script>
   <script type="module">
-      onFdc3Ready().then(async() => {
-        await closeWindowOnCompletion(window.fdc3);
-        window.fdc3.addIntentListener('bTestingIntent', async (context) => {
-          return context;
-        });
-        window.fdc3.addIntentListener('sharedTestingIntent1', async (context) => {
-          return context;
-        });
-        window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
-          window.fdc3.addContextListener(null, (context) => {
+    onFdc3Ready().then(async () => {
+      await closeWindowOnCompletion(window.fdc3);
+      window.fdc3.addIntentListener('bTestingIntent', async (context) => {
+        return context;
+      });
+      window.fdc3.addIntentListener('sharedTestingIntent1', async (context) => {
+        return context;
+      });
+      window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
+        window.fdc3.addContextListener(null, (context) => {
           // broadcast that this app has received context
           window.fdc3.broadcast({
             type: "fdc3-conformance-context-received",

--- a/mock/intent-b/index.html
+++ b/mock/intent-b/index.html
@@ -11,7 +11,7 @@
   <script src="lib/mock-functions.js"></script>
   <script type="module">
     onFdc3Ready().then(async () => {
-      await closeWindowOnCompletion(window.fdc3);
+      await closeWindowOnCompletion();
       window.fdc3.addIntentListener('bTestingIntent', async (context) => {
         return context;
       });

--- a/mock/intent-c/index.html
+++ b/mock/intent-c/index.html
@@ -1,24 +1,27 @@
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="index.css" />
-  </head>
-  <body>
-    <p>Conformance Framework Mock Intent App C</p>
-    <p>This app is only used by the conformance framework for intent test purposes.</p>
-    <script src="lib/mock-functions.js"></script>
-   <script type="module">
-      onFdc3Ready().then(async () => {
-        await closeWindowOnCompletion(window.fdc3);
-        window.fdc3.addIntentListener('cTestingIntent', async (context) => {
-          return context;
-        });
-        window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
-          window.fdc3.broadcast({
-            type: "fdc3-intent-c-opened",
-          });
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="index.css" />
+</head>
+
+<body>
+  <p>Conformance Framework Mock Intent App C</p>
+  <p>This app is only used by the conformance framework for intent test purposes.</p>
+  <script src="lib/mock-functions.js"></script>
+  <script type="module">
+    onFdc3Ready().then(async () => {
+      await closeWindowOnCompletion(window.fdc3);
+      window.fdc3.addIntentListener('cTestingIntent', async (context) => {
+        return context;
+      });
+      window.fdc3.joinChannel("fdc3.raiseIntent").then(() => {
+        window.fdc3.broadcast({
+          type: "fdc3-intent-c-opened",
         });
       });
-    </script>
-  </body>
+    });
+  </script>
+</body>
+
 </html>

--- a/mock/intent-c/index.html
+++ b/mock/intent-c/index.html
@@ -11,7 +11,7 @@
   <script src="lib/mock-functions.js"></script>
   <script type="module">
     onFdc3Ready().then(async () => {
-      await closeWindowOnCompletion(window.fdc3);
+      await closeWindowOnCompletion();
       window.fdc3.addIntentListener('cTestingIntent', async (context) => {
         return context;
       });

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -10,15 +10,15 @@ const onFdc3Ready = () =>
   const closeWindowOnCompletion = async (fdc3) => {
     let implementationMetadata = await fdc3.getInfo();
     let {fdc3Version} = implementationMetadata;
+    const appControlChannel = await fdc3.getOrCreateChannel("app-control");
     if(fdc3Version === "1.2"){
-      await closeWindowOnCompletion_1_2();
+      await closeWindowOnCompletion_1_2(appControlChannel);
     }else if(fdc3Version === "2.0"){
-      await closeWindowOnCompletion_2_0();
+      await closeWindowOnCompletion_2_0(appControlChannel);
     }
   }
 
-const closeWindowOnCompletion_1_2 = async () => {
-  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+const closeWindowOnCompletion_1_2 = async (appControlChannel) => {
   appControlChannel.addContextListener("closeWindow", async (context) => {
     //notify app A that window was closed
     appControlChannel.broadcast({
@@ -31,8 +31,7 @@ const closeWindowOnCompletion_1_2 = async () => {
   });
 };
 
-const closeWindowOnCompletion_2_0 = async () => {
-  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+const closeWindowOnCompletion_2_0 = async (appControlChannel) => {
   await appControlChannel.addContextListener("closeWindow", async (context) => {
     //notify app A that window was closed
     await appControlChannel.broadcast({

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -1,26 +1,57 @@
-const onFdc3Ready = () => new Promise((resolve) => {
-  if (window.fdc3) {
+const onFdc3Ready = () =>
+  new Promise((resolve) => {
+    if (window.fdc3) {
       resolve();
-  } else {
-      window.addEventListener('fdc3Ready', () => resolve());
+    } else {
+      window.addEventListener("fdc3Ready", () => resolve());
+    }
+  });
+
+  const closeWindowOnCompletion = async (fdc3) => {
+    let implementationMetadata = await fdc3.getInfo();
+    let {fdc3Version} = implementationMetadata;
+    if(fdc3Version === "1.2"){
+      await closeWindowOnCompletion_1_2();
+    }else if(fdc3Version === "2.0"){
+      await closeWindowOnCompletion_2_0();
+    }
   }
-});
 
-const closeWindowOnCompletion = async (fdc3) => {
-  const appControlChannel = await window.fdc3.getOrCreateChannel(
-      "app-control"
-    );
-   appControlChannel.addContextListener("closeWindow", async (context) => {
-
-      //notify app A that window was closed
-      appControlChannel.broadcast({
-        type: "windowClosed",
-        testId: context.testId,
-      });
-      setTimeout(() => {
-        //yield to make sure the broadcast gets out before we close
-        window.close();
-        return;
-      }, 1);
+const closeWindowOnCompletion_1_2 = async () => {
+  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+  appControlChannel.addContextListener("closeWindow", async (context) => {
+    //notify app A that window was closed
+    appControlChannel.broadcast({
+      type: "windowClosed",
+      testId: context.testId,
+    });
+    await sleep(10);
+    //yield to make sure the broadcast gets out before we close
+    window.close();
   });
 };
+
+const closeWindowOnCompletion_2_0 = async () => {
+  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
+  await appControlChannel.addContextListener("closeWindow", async (context) => {
+    //notify app A that window was closed
+    await appControlChannel.broadcast({
+      type: "windowClosed",
+      testId: context.testId,
+    });
+    await sleep(10);
+    //yield to make sure the broadcast gets out before we close
+    window.close();
+  });
+};
+
+async function sleep(timeoutMs) {
+  let timeout;
+  const promise = new Promise((resolve) => {
+    timeout = window.setTimeout(() => {
+      resolve();
+    }, timeoutMs);
+  });
+  return { promise, timeout };
+}
+

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -7,16 +7,16 @@ const onFdc3Ready = () =>
     }
   });
 
-  const closeWindowOnCompletion = async (fdc3) => {
-    let implementationMetadata = await fdc3.getInfo();
-    let {fdc3Version} = implementationMetadata;
-    const appControlChannel = await fdc3.getOrCreateChannel("app-control");
-    if(fdc3Version === "1.2"){
-      await closeWindowOnCompletion_1_2(appControlChannel);
-    }else if(fdc3Version === "2.0"){
-      await closeWindowOnCompletion_2_0(appControlChannel);
-    }
+const closeWindowOnCompletion = async (fdc3) => {
+  let implementationMetadata = await fdc3.getInfo();
+  let { fdc3Version } = implementationMetadata;
+  const appControlChannel = await fdc3.getOrCreateChannel("app-control");
+  if (fdc3Version === "1.2") {
+    await closeWindowOnCompletion_1_2(appControlChannel);
+  } else if (fdc3Version === "2.0") {
+    await closeWindowOnCompletion_2_0(appControlChannel);
   }
+};
 
 const closeWindowOnCompletion_1_2 = async (appControlChannel) => {
   appControlChannel.addContextListener("closeWindow", async (context) => {
@@ -46,11 +46,9 @@ const closeWindowOnCompletion_2_0 = async (appControlChannel) => {
 
 async function sleep(timeoutMs) {
   let timeout;
-  const promise = new Promise((resolve) => {
+  return new Promise((resolve) => {
     timeout = window.setTimeout(() => {
       resolve();
     }, timeoutMs);
   });
-  return { promise, timeout };
 }
-

--- a/mock/mock-functions.js
+++ b/mock/mock-functions.js
@@ -7,48 +7,18 @@ const onFdc3Ready = () =>
     }
   });
 
-const closeWindowOnCompletion = async (fdc3) => {
-  let implementationMetadata = await fdc3.getInfo();
-  let { fdc3Version } = implementationMetadata;
-  const appControlChannel = await fdc3.getOrCreateChannel("app-control");
-  if (fdc3Version === "1.2") {
-    await closeWindowOnCompletion_1_2(appControlChannel);
-  } else if (fdc3Version === "2.0") {
-    await closeWindowOnCompletion_2_0(appControlChannel);
-  }
-};
-
-const closeWindowOnCompletion_1_2 = async (appControlChannel) => {
-  appControlChannel.addContextListener("closeWindow", async (context) => {
-    //notify app A that window was closed
-    appControlChannel.broadcast({
-      type: "windowClosed",
-      testId: context.testId,
-    });
-    await sleep(10);
-    //yield to make sure the broadcast gets out before we close
-    window.close();
-  });
-};
-
-const closeWindowOnCompletion_2_0 = async (appControlChannel) => {
+const closeWindowOnCompletion = async () => {
+  const appControlChannel = await window.fdc3.getOrCreateChannel("app-control");
   await appControlChannel.addContextListener("closeWindow", async (context) => {
     //notify app A that window was closed
     await appControlChannel.broadcast({
       type: "windowClosed",
       testId: context.testId,
     });
-    await sleep(10);
-    //yield to make sure the broadcast gets out before we close
-    window.close();
+    setTimeout(() => {
+      //yield to make sure the broadcast gets out before we close
+      window.close();
+      return;
+    }, 5);
   });
 };
-
-async function sleep(timeoutMs) {
-  let timeout;
-  return new Promise((resolve) => {
-    timeout = window.setTimeout(() => {
-      resolve();
-    }, timeoutMs);
-  });
-}


### PR DESCRIPTION
- to avoid confusion, I've split `closeWindowOnCompletion` into two so that `await` is used in front of fdc3 API calls when it should, and isn't used when it shouldn't
- also added sleep function after broadcasting to give mock apps time to close
- removed unused listener