### PR TITLE
Remove incorrect check from BasicJC1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
   WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
   WindowCloseWaitTime: 750, // The amount of time to allow for clean-up of closed windows
-  NoListenerTimeout: 61000 // the amount of time to allow for a DA to timeout waiting on a context or intent listener
+  NoListenerTimeout: 75000 // the amount of time to allow for a DA to timeout waiting on a context or intent listener
                            // FDC3 does not define this timeout so this should be extended if the DA uses a longer timeout
 } as const;
 

--- a/src/test/v1.2/basic/fdc3.joinChannel.ts
+++ b/src/test/v1.2/basic/fdc3.joinChannel.ts
@@ -26,7 +26,7 @@ export default () =>
       await fdc3.leaveCurrentChannel();
     });
 
-    it("(BasicJC1) Can join channel and broadcast", async () => {
+    it("(BasicJC1) Can join channel", async () => {
       const channels = await fdc3.getSystemChannels();
 
       if (channels.length > 0) {

--- a/src/test/v1.2/basic/fdc3.joinChannel.ts
+++ b/src/test/v1.2/basic/fdc3.joinChannel.ts
@@ -27,7 +27,6 @@ export default () =>
     });
 
     it("(BasicJC1) Can join channel and broadcast", async () => {
-      const wrapper = wrapPromise();
       const channels = await fdc3.getSystemChannels();
 
       if (channels.length > 0) {
@@ -38,24 +37,6 @@ export default () =>
 
           expect(currentChannel).to.not.be.null;
 
-          const gotContext = (c) => {
-            return true;
-          };
-
-          fdc3.addContextListener("someContext", (ctx) => {
-            if (ctx.type == "someContext") {
-              wrapper.resolve();
-            } else {
-              wrapper.reject("wrong context type");
-            }
-          });
-
-          currentChannel.broadcast({
-            type: "someContext",
-            id: { name: "hello" },
-          });
-
-          await wrapper.promise;
         } catch (ex) {
           assert.fail("Error while joining channel: " + (ex.message ?? ex));
         }


### PR DESCRIPTION
Removes a check from BasicJC1 that was based on an app broadcasting a context and then receiving it back - the Standard recommends that this is prevented 

> Channel implementations SHOULD ensure that context messages broadcast by an application on a channel are not delivered back to that same application if they are also listening on the channel.

https://fdc3.finos.org/docs/api/spec#types-of-channel

As the advanced System Channel checks already cover broadcast to the channel and receipt by other apps this check is not needed (and went beyond test definition anyway)

Based on PR #131 which should be merged first