### PR TITLE
Correct error in intent-app-b

### DIFF
--- a/directories/finsemble.app-d-snippet.txt
+++ b/directories/finsemble.app-d-snippet.txt
@@ -66,7 +66,7 @@
             "affinity": "workspaceComponents",
             "options": {
                 "resizable": true,
-                "autoShow": false,
+                "autoShow": true,
                 "alwaysOnTop": false,
                 "addToWorkspace": true
             },
@@ -104,8 +104,8 @@
             }
         }
     },
-    "icons": [{"src": "http://localhost:3000/pathToIcon.png"}],
-    "images": [{"src": "http://localhost:3000/pathToImage.png"}],
+    "icons": [{"src": "http://localhost:3001/pathToIcon.png"}],
+    "images": [{"src": "http://localhost:3001/pathToImage.png"}],
     "version": "1.0.0",
     "publisher": "Scott Logic"
 },
@@ -119,7 +119,7 @@
             "affinity": "workspaceComponents",
             "options": {
                 "resizable": true,
-                "autoShow": false,
+                "autoShow": true,
                 "alwaysOnTop": false,
                 "addToWorkspace": true
             },
@@ -161,7 +161,7 @@
     "publisher": "Scott Logic",
     "icons": [
         {
-            "src": "http://localhost:3000/scott-logic-icon-256.png"
+            "src": "http://localhost:3001/scott-logic-icon-256.png"
         }
     ],
     "intents": [
@@ -187,7 +187,7 @@
             "affinity": "workspaceComponents",
             "options": {
                 "resizable": true,
-                "autoShow": false,
+                "autoShow": true,
                 "alwaysOnTop": false,
                 "addToWorkspace": true
             },
@@ -255,7 +255,7 @@
             "affinity": "workspaceComponents",
             "options": {
                 "resizable": true,
-                "autoShow": false,
+                "autoShow": true,
                 "alwaysOnTop": false,
                 "addToWorkspace": true
             },
@@ -318,7 +318,7 @@
 			"affinity": "workspaceComponents",
 			"options": {
 				"resizable": true,
-				"autoShow": false,
+				"autoShow": true,
 				"alwaysOnTop": false,
 				"addToWorkspace": true
 			},
@@ -360,7 +360,7 @@
 	"publisher": "Scott Logic",
 	"icons": [
 		{
-			"src": "http://localhost:3000/scott-logic-icon-256.png"
+			"src": "http://localhost:3001/scott-logic-icon-256.png"
 		}
 	]
 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
   WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
   WindowCloseWaitTime: 750, // The amount of time to allow for clean-up of closed windows
-  NoListenerTimeout: 61000 // the amount of time to allow for a DA to timeout waiting on a context or intent listener
+  NoListenerTimeout: 75000 // the amount of time to allow for a DA to timeout waiting on a context or intent listener
                            // FDC3 does not define this timeout so this should be extended if the DA uses a longer timeout
 } as const;
 

--- a/src/mock/v1.2/intent-b.ts
+++ b/src/mock/v1.2/intent-b.ts
@@ -15,6 +15,6 @@ onFdc3Ready().then(async () => {
 
     //broadcast that intent-a has opened
     await sendContextToTests({
-        type: "fdc3-intent-a-opened"
+        type: "fdc3-intent-b-opened"
     });
 });

--- a/src/mock/v1.2/mock-functions.ts
+++ b/src/mock/v1.2/mock-functions.ts
@@ -13,6 +13,7 @@ export const onFdc3Ready = () =>
   });
 
 export const closeWindowOnCompletion = async () => {
+  console.log("Setting up closeWindow listener on app-control channel");
   const appControlChannel = await fdc3.getOrCreateChannel("app-control");
   appControlChannel.addContextListener("closeWindow", async (context : AppControlContext) => {
     //notify app A that window was closed
@@ -29,6 +30,7 @@ export const closeWindowOnCompletion = async () => {
 };
 
 export const sendContextToTests = async(context) =>{
+  console.log("Sending context to app-control channel: ", context);
   const appControlChannel = await fdc3.getOrCreateChannel(
     "app-control"
   );

--- a/src/test/v1.2/basic/fdc3.joinChannel.ts
+++ b/src/test/v1.2/basic/fdc3.joinChannel.ts
@@ -27,7 +27,6 @@ export default () =>
     });
 
     it("(BasicJC1) Can join channel and broadcast", async () => {
-      const wrapper = wrapPromise();
       const channels = await fdc3.getSystemChannels();
 
       if (channels.length > 0) {
@@ -38,24 +37,6 @@ export default () =>
 
           expect(currentChannel).to.not.be.null;
 
-          const gotContext = (c) => {
-            return true;
-          };
-
-          fdc3.addContextListener("someContext", (ctx) => {
-            if (ctx.type == "someContext") {
-              wrapper.resolve();
-            } else {
-              wrapper.reject("wrong context type");
-            }
-          });
-
-          currentChannel.broadcast({
-            type: "someContext",
-            id: { name: "hello" },
-          });
-
-          await wrapper.promise;
         } catch (ex) {
           assert.fail("Error while joining channel: " + (ex.message ?? ex));
         }


### PR DESCRIPTION
Corrects a small error in the Intent App B implementation that was breaking the execution of SingleResolve1.

Also: 
- adds some log messages to mock-functions to ease future debugging
- updates FInsemble config snippet to show apps launched (rather than hide) - this change was made previously but has been reverted at some point

This PR builds on:
https://github.com/finos/FDC3-conformance-framework/pull/131
https://github.com/finos/FDC3-conformance-framework/pull/132

which should be merged first