### PR TITLE
App channel fixes rm

### DIFF
--- a/directories/local-conformance-1_2.v2.json
+++ b/directories/local-conformance-1_2.v2.json
@@ -189,6 +189,7 @@
       },
       "version": "1.0.0",
       "publisher": "Scott Logic",
+      "type": "web",
       "icons": [
         {
           "src": "https://localhost:3001/finos-icon-256.png"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@
  * Constants used in compliance testing
  */
  const constants = {
+  ShortWait: 1000, // used temporarily to avoid race conditions in the tests - replace with promises.  
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 9000, // Tests that take longer than this (in milliseconds) will fail
   WaitTime: 3000, // The amount of time to wait for mock apps to finish processing

--- a/src/test/common/channel-control.ts
+++ b/src/test/common/channel-control.ts
@@ -19,8 +19,8 @@ export interface ChannelControl<X, Y> {
   
     // listening
     initCompleteListener(testId: string): Promise<Y>
-    setupAndValidateListener1(channel: X | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
-    setupAndValidateListener2(channel: X | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
+    setupAndValidateListener1(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
+    setupAndValidateListener2(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
     setupContextChecker(channel: X, requestedContextType: string, expectedContextType: string, errorMessage: string, onComplete: (ctx: Y) => void): Promise<void>;
     validateContextIsNotReceived(channel: X | null, unexpectedContextType: string | null, errorMessage: string): void | Promise<void>;
 

--- a/src/test/common/channel-control.ts
+++ b/src/test/common/channel-control.ts
@@ -22,7 +22,6 @@ export interface ChannelControl<X, Y> {
     setupAndValidateListener1(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
     setupAndValidateListener2(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
     setupContextChecker(channel: X, requestedContextType: string, expectedContextType: string, errorMessage: string, onComplete: (ctx: Y) => void): Promise<void>;
-    validateContextIsNotReceived(channel: X | null, unexpectedContextType: string | null, errorMessage: string): void | Promise<void>;
 
     // helpers
     getRandomId(): string;

--- a/src/test/common/fdc3.app-channels.ts
+++ b/src/test/common/fdc3.app-channels.ts
@@ -20,7 +20,7 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const testChannel = await cc.createRandomTestChannel()
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(testChannel, null, errorMessage, () => { receivedContext = true })
+        await cc.setupAndValidateListener1(testChannel, null, "fdc3.instrument", errorMessage, () => { receivedContext = true })
         await cc.openChannelApp(acTestId, testChannel.id, APP_CHANNEL_AND_BROADCAST)
         await resolveExecutionCompleteListener;
 
@@ -54,7 +54,7 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const testChannel = await cc.createRandomTestChannel()
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId4)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", errorMessage, () => { receivedContext = true })
+        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "fdc3.instrument", errorMessage, () => { receivedContext = true })
         await cc.validateContextIsNotReceived(testChannel, "fdc3.contact",  `Should not have received "fdc3.contact" context. ${errorMessage}`);
         await cc.openChannelApp(acTestId4, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE)
         await resolveExecutionCompleteListener;
@@ -73,12 +73,12 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const testChannel = await cc.createRandomTestChannel()
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId5);
 
-        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", errorMessage, (context) => {
+        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument","fdc3.instrument", errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         })
 
-        await cc.setupAndValidateListener1(testChannel, "fdc3.contact", errorMessage, (context) => {
+        await cc.setupAndValidateListener1(testChannel, "fdc3.contact",  "fdc3.contact", errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         })
@@ -114,7 +114,7 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const testChannel = await cc.createRandomTestChannel()
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId6)
 
-        await cc.setupAndValidateListener1(testChannel, "unexpected-context", errorMessage, () => { /*noop*/ })
+        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
         await cc.unsubscribeListeners()
 
         await cc.validateContextIsNotReceived(testChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
@@ -129,7 +129,7 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves an app channel\r\n- App A adds a context listener of type fdc3.instrument\r\n- App B retrieves a different app channel\r\n- App B broadcasts a context of type fdc3.instrument${documentation}`;
 
         const testChannel = await cc.createRandomTestChannel();
-        await cc.setupAndValidateListener1(testChannel, "unexpected-context", errorMessage, () => { /*noop*/ })
+        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
         await cc.validateContextIsNotReceived(testChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
         await cc.validateContextIsNotReceived(testChannel, "fdc3.contact", `Should not have received "fdc3.contact" context. ${errorMessage}`);
         const differentTestChannel = await cc.createRandomTestChannel();
@@ -147,8 +147,8 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId8)
         const differentAppChannel = await cc.createRandomTestChannel();
-        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", errorMessage, () => { receivedContext = true })
-        await cc.setupAndValidateListener2(differentAppChannel, "unexpected-context", errorMessage, () => { /*noop*/ })
+        await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "fdc3.instrument", errorMessage, () => { receivedContext = true })
+        await cc.setupAndValidateListener2(differentAppChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
         await cc.validateContextIsNotReceived(differentAppChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
         await cc.validateContextIsNotReceived(differentAppChannel, "fdc3.contact", `Should not have received "fdc3.contact" context. ${errorMessage}`);
         await cc.openChannelApp(acTestId8, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE)

--- a/src/test/common/fdc3.app-channels.ts
+++ b/src/test/common/fdc3.app-channels.ts
@@ -55,7 +55,6 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const resolveExecutionCompleteListener = cc.initCompleteListener(acTestId4)
         let receivedContext = false;
         await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "fdc3.instrument", errorMessage, () => { receivedContext = true })
-        await cc.validateContextIsNotReceived(testChannel, "fdc3.contact",  `Should not have received "fdc3.contact" context. ${errorMessage}`);
         await cc.openChannelApp(acTestId4, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE)
         await resolveExecutionCompleteListener;
 
@@ -117,7 +116,6 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
         await cc.unsubscribeListeners()
 
-        await cc.validateContextIsNotReceived(testChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
         await cc.openChannelApp(acTestId6, testChannel.id, APP_CHANNEL_AND_BROADCAST)
 
         await resolveExecutionCompleteListener;
@@ -130,8 +128,6 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
 
         const testChannel = await cc.createRandomTestChannel();
         await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
-        await cc.validateContextIsNotReceived(testChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
-        await cc.validateContextIsNotReceived(testChannel, "fdc3.contact", `Should not have received "fdc3.contact" context. ${errorMessage}`);
         const differentTestChannel = await cc.createRandomTestChannel();
         await cc.openChannelApp(acTestId7, differentTestChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE)
         await wait();
@@ -149,8 +145,6 @@ export function createAppChannelTests(cc: ChannelControl<any,any>, documentation
         const differentAppChannel = await cc.createRandomTestChannel();
         await cc.setupAndValidateListener1(testChannel, "fdc3.instrument", "fdc3.instrument", errorMessage, () => { receivedContext = true })
         await cc.setupAndValidateListener2(differentAppChannel, "fdc3.instrument", "unexpected-context", errorMessage, () => { /*noop*/ })
-        await cc.validateContextIsNotReceived(differentAppChannel, "fdc3.instrument", `Should not have received "fdc3.instrument" context. ${errorMessage}`);
-        await cc.validateContextIsNotReceived(differentAppChannel, "fdc3.contact", `Should not have received "fdc3.contact" context. ${errorMessage}`);
         await cc.openChannelApp(acTestId8, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE)
         await resolveExecutionCompleteListener;
         if (!receivedContext) {

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -20,7 +20,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId1)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, null, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
         await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
@@ -38,7 +38,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId2)
         const channel = await cc.retrieveAndJoinChannel(1);
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, null, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
         await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
 
@@ -57,7 +57,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
         await cc.openChannelApp(scTestId3, channel.id, JOIN_AND_BROADCAST);
         await cc.joinChannel(channel);
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, null, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
         await resolveExecutionCompleteListener;
 
         if (!receivedContext) {
@@ -72,7 +72,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId4)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "fdc3.instrument", errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
         await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
@@ -104,12 +104,12 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
           }
         }
 
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, (context) => {
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "fdc3.instrument", errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         });
 
-        await cc.setupAndValidateListener2(null, "fdc3.contact", errorMessage, (context) => {
+        await cc.setupAndValidateListener2(null, "fdc3.contact", "fdc3.contact", errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         });
@@ -130,8 +130,8 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       it(scTestId6, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
-        await cc.setupAndValidateListener1(null, "unexpected-context", errorMessage, () =>  {/* noop */});
-        await cc.setupAndValidateListener2(null, "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () =>  {/* noop */});
 
         const channels = await cc.getSystemChannels();
         if (channels.length < 1)
@@ -148,7 +148,8 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A unsubscribes the listener\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId7)
-        await cc.setupAndValidateListener1(null, "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () =>  {/* noop */});
         const channel = await cc.retrieveAndJoinChannel(1);
         await cc.unsubscribeListeners();
         await cc.openChannelApp(scTestId7, channel.id, JOIN_AND_BROADCAST);
@@ -160,7 +161,8 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       it(scTestId8, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
-        await cc.setupAndValidateListener1(null, "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument",  "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener2(null, "fdc3.contact",  "unexpected-context", errorMessage, () =>  {/* noop */});
         const channels = await cc.getSystemChannels(); 
         if (channels.length < 1) {
           assert.fail("No system channels available for app A");

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -1,9 +1,14 @@
 import { assert } from "chai";
+import { DesktopAgent } from "fdc3_1_2";
 import { wait } from "../../utils";
-import { JOIN_AND_BROADCAST, JOIN_AND_BROADCAST_TWICE } from "../common/channel-control";
+import { commands, JOIN_AND_BROADCAST, JOIN_AND_BROADCAST_TWICE } from "../common/channel-control";
+import { buildChannelsAppContext } from "../v1.2/advanced/channels-support-1.2";
+import { ChannelsAppConfig } from "../v2.0/advanced/fdc3.broadcast";
 import { ChannelControl } from "./channel-control";
 
-export function createUserChannelTests(cc: ChannelControl<any,any>, documentation: string, prefix: string): Mocha.Suite {
+declare let fdc3: DesktopAgent
+
+export function createUserChannelTests(cc: ChannelControl<any, any>, documentation: string, prefix: string): Mocha.Suite {
   return describe("fdc3.broadcast", () => {
     describe("System channels", () => {
       beforeEach(cc.channelCleanUp);
@@ -14,7 +19,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId1 =
-        "("+prefix+"UCBasicUsage1) Should receive context when adding a listener then joining a user channel before app B broadcasts context to the same channel";
+        "(" + prefix + "UCBasicUsage1) Should receive context when adding a listener then joining a user channel before app B broadcasts context to the same channel";
       it(scTestId1, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- Add fdc3.instrument context listener to app A\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
@@ -31,7 +36,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId2 =
-        "("+prefix+"UCBasicUsage2) Should receive context when joining a user channel then adding a context listener before app B broadcasts context to the same channel";
+        "(" + prefix + "UCBasicUsage2) Should receive context when joining a user channel then adding a context listener before app B broadcasts context to the same channel";
       it(scTestId2, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A joins channel 1\r\n- Add listener of type fdc3.instrument to App A\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
@@ -48,7 +53,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId3 =
-        "("+prefix+"UCBasicUsage3) Should receive context when app B joins then broadcasts context to a user channel before A joins and listens on the same channel";
+        "(" + prefix + "UCBasicUsage3) Should receive context when app B joins then broadcasts context to a user channel before A joins and listens on the same channel";
       it(scTestId3, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context\r\n- App A joins channel 1\r\n- App A adds fdc3.instrument context listener${documentation}`;
 
@@ -66,7 +71,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId4 =
-        "("+prefix+"UCFilteredContext1) Should receive context when app A joins a user channel before adding a listener and app B broadcasts the listened type to the same user channel";
+        "(" + prefix + "UCFilteredContext1) Should receive context when app A joins a user channel before adding a listener and app B broadcasts the listened type to the same user channel";
       it(scTestId4, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
@@ -83,7 +88,7 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId5 =
-        "("+prefix+"UCFilteredContext2) Should receive multiple contexts when app B broadcasts the listened types to the same user channel";
+        "(" + prefix + "UCFilteredContext2) Should receive multiple contexts when app B broadcasts the listened types to the same user channel";
       it(scTestId5, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
@@ -126,30 +131,30 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId6 =
-        "("+prefix+"UCFilteredContext3) Should not receive context when A & B join different user channels and app B broadcasts a listened type";
+        "(" + prefix + "UCFilteredContext3) Should not receive context when A & B join different user channels and app B broadcasts a listened type";
       it(scTestId6, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds fdc3.instrument and fdc3.contact context listener\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts both context types${documentation}`;
 
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () =>  {/* noop */});
-        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () => {/* noop */ });
+        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () => {/* noop */ });
 
         const channels = await cc.getSystemChannels();
         if (channels.length < 1)
           assert.fail("No system channels available for app A");
 
-        await cc.joinChannel(channels[0]) ; 
+        await cc.joinChannel(channels[0]);
         await cc.openChannelApp(scTestId6, channels[1].id, JOIN_AND_BROADCAST_TWICE);
         await wait();
       });
 
       const scTestId7 =
-        "("+prefix+"UCUnsubscribe) Should not receive context when unsubscribing a user channel before app B broadcasts the listened type to that channel";
+        "(" + prefix + "UCUnsubscribe) Should not receive context when unsubscribing a user channel before app B broadcasts the listened type to that channel";
       it(scTestId7, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A unsubscribes the listener\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId7)
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () =>  {/* noop */});
-        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, () => {/* noop */ });
+        await cc.setupAndValidateListener2(null, "fdc3.contact", "unexpected-context", errorMessage, () => {/* noop */ });
         const channel = await cc.retrieveAndJoinChannel(1);
         await cc.unsubscribeListeners();
         await cc.openChannelApp(scTestId7, channel.id, JOIN_AND_BROADCAST);
@@ -157,23 +162,25 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       });
 
       const scTestId8 =
-        "("+prefix+"UCFilteredContext4) Should not receive context when joining two different user channels before app B broadcasts the listened type to the first channel that was joined";
+        "(" + prefix + "UCFilteredContext4) Should not receive context when joining two different user channels before app B broadcasts the listened type to the first channel that was joined";
       it(scTestId8, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
-        await cc.setupAndValidateListener1(null, "fdc3.instrument",  "unexpected-context", errorMessage, () =>  {/* noop */});
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, async () => {/* noop */ });
         await cc.setupAndValidateListener2(null, "fdc3.contact",  "unexpected-context", errorMessage, () =>  {/* noop */});
-        const channels = await cc.getSystemChannels(); 
+        
+        const channels = await cc.getSystemChannels();
         if (channels.length < 1) {
           assert.fail("No system channels available for app A");
         }
 
         await cc.joinChannel(channels[0]);
         await cc.joinChannel(channels[1]);
-        await cc.openChannelApp(scTestId8, channels[0].id, JOIN_AND_BROADCAST_TWICE);
+        await cc.openChannelApp(scTestId8, channels[0].id, JOIN_AND_BROADCAST);
         await wait();
       });
 
     });
+
   });
 }

--- a/src/test/v1.2/advanced/channels-support-1.2.ts
+++ b/src/test/v1.2/advanced/channels-support-1.2.ts
@@ -102,16 +102,16 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
     );
   }
 
-  setupAndValidateListener1 = (channel: Channel, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void): void => {
+  setupAndValidateListener1 = (channel: Channel, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void): void => {
     if (channel) {
-      listener1 = channel.addContextListener(expectedContextType, (context) => {
+      listener1 = channel.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }
         onComplete(context);
       });
     } else {
-      listener1 = fdc3.addContextListener(expectedContextType, (context) => {
+      listener1 = fdc3.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }
@@ -122,16 +122,16 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
     validateListenerObject(listener1);
   }
 
-  setupAndValidateListener2 = (channel: Channel, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void): void => {
+  setupAndValidateListener2 = (channel: Channel, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void): void => {
     if (channel) {
-      listener2 = channel.addContextListener(expectedContextType, (context) => {
+      listener2 = channel.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }
         onComplete(context);
       });
     } else {
-      listener2 = fdc3.addContextListener(expectedContextType, (context) => {
+      listener2 = fdc3.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }

--- a/src/test/v1.2/advanced/channels-support-1.2.ts
+++ b/src/test/v1.2/advanced/channels-support-1.2.ts
@@ -73,14 +73,16 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
     await wait(constants.WindowCloseWaitTime);
   }
 
-
-
-  initCompleteListener = async (testId: string): Promise<Context> => {
-    return waitForContext(
+  initCompleteListener = async (testId: string) : Promise<Context>  => {
+    const receivedContext = await waitForContext(
       "executionComplete",
       testId,
       await fdc3.getOrCreateChannel("app-control")
     );
+    
+    await wait(constants.ShortWait)
+
+    return receivedContext;
   }
 
   openChannelApp = async (testId: string, channelId: string | undefined, commands: string[], historyItems: number = undefined, notify: boolean = true): Promise<void> => {

--- a/src/test/v1.2/advanced/channels-support-1.2.ts
+++ b/src/test/v1.2/advanced/channels-support-1.2.ts
@@ -156,18 +156,6 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
     return uint32.toString(16);
   }
 
-  validateContextIsNotReceived = (channel: Channel | null, unexpectedContextType: string, errorMessage: string): void => {
-    // if (channel) {
-    //   listener1 = channel.addContextListener(unexpectedContextType, (context) => {
-    //     assert.fail(errorMessage);
-    //   });
-    // } else {
-    //   listener1 = fdc3.addContextListener(unexpectedContextType, (context) => {
-    //     assert.fail(errorMessage);
-    //   });
-    // }
-    // validateListenerObject(listener1);
-  }
 }
 
 

--- a/src/test/v1.2/advanced/channels-support-1.2.ts
+++ b/src/test/v1.2/advanced/channels-support-1.2.ts
@@ -38,7 +38,7 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
   };
 
   joinChannel = async (channel: Channel): Promise<void> => {
-    return fdc3.joinChannel(channel.id)
+    return await fdc3.joinChannel(channel.id)
   }
 
   createRandomTestChannel = async (): Promise<Channel> => {
@@ -157,16 +157,16 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
   }
 
   validateContextIsNotReceived = (channel: Channel | null, unexpectedContextType: string, errorMessage: string): void => {
-    if (channel) {
-      listener1 = channel.addContextListener(unexpectedContextType, (context) => {
-        assert.fail(errorMessage);
-      });
-    } else {
-      listener1 = fdc3.addContextListener(unexpectedContextType, (context) => {
-        assert.fail(errorMessage);
-      });
-    }
-    validateListenerObject(listener1);
+    // if (channel) {
+    //   listener1 = channel.addContextListener(unexpectedContextType, (context) => {
+    //     assert.fail(errorMessage);
+    //   });
+    // } else {
+    //   listener1 = fdc3.addContextListener(unexpectedContextType, (context) => {
+    //     assert.fail(errorMessage);
+    //   });
+    // }
+    // validateListenerObject(listener1);
   }
 }
 
@@ -276,7 +276,7 @@ const waitForContext = (
 };
 
 
-function buildChannelsAppContext(
+export function buildChannelsAppContext(
   mockAppCommands: string[],
   config: ChannelsAppConfig
 ): ChannelsAppContext {

--- a/src/test/v2.0/advanced/channels-support-2.0.ts
+++ b/src/test/v2.0/advanced/channels-support-2.0.ts
@@ -103,9 +103,9 @@ export class ChannelControl2_0 implements ChannelControl<Channel, Context> {
     );
   }
 
-  setupAndValidateListener1 = async (channel: Channel, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void) => {
+  setupAndValidateListener1 = async (channel: Channel,  listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Context) => void) => {
     if (channel) {
-      listener1 = await channel.addContextListener(expectedContextType, (context) => {
+      listener1 = await channel.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }
@@ -123,9 +123,9 @@ export class ChannelControl2_0 implements ChannelControl<Channel, Context> {
     validateListenerObject(listener1);
   }
 
-  setupAndValidateListener2 = async (channel: Channel, expectedContextType: string, errorMessage: string, onComplete: (ctx: Context) => void) => {
+  setupAndValidateListener2 = async (channel: Channel, listenContextType: string | null, expectedContextType: string, errorMessage: string, onComplete: (ctx: Context) => void) => {
     if (channel) {
-      listener2 = await channel.addContextListener(expectedContextType, (context) => {
+      listener2 = await channel.addContextListener(listenContextType, (context) => {
         if (expectedContextType != null) {
           expect(context.type).to.be.equals(expectedContextType, errorMessage);
         }

--- a/src/test/v2.0/advanced/channels-support-2.0.ts
+++ b/src/test/v2.0/advanced/channels-support-2.0.ts
@@ -157,19 +157,6 @@ export class ChannelControl2_0 implements ChannelControl<Channel, Context> {
     return uint32.toString(16);
   }
 
-  validateContextIsNotReceived = async(channel: Channel | null, unexpectedContextType: string, errorMessage: string): Promise<void> => {
-    if (channel) {
-      listener1 = await channel.addContextListener(unexpectedContextType, (context) => {
-        assert.fail(errorMessage);
-      });
-    } else {
-      listener1 = await fdc3.addContextListener(unexpectedContextType, (context) => {
-        assert.fail(errorMessage);
-      });
-    }
-    validateListenerObject(listener1);
-  }
-
 }
 
 

--- a/src/test/v2.0/advanced/channels-support-2.0.ts
+++ b/src/test/v2.0/advanced/channels-support-2.0.ts
@@ -74,14 +74,16 @@ export class ChannelControl2_0 implements ChannelControl<Channel, Context> {
     await wait(constants.WindowCloseWaitTime);
   }
 
-
-
   initCompleteListener = async (testId: string) => {
-    return waitForContext(
+    const receivedContext = await waitForContext(
       "executionComplete",
       testId,
       await fdc3.getOrCreateChannel("app-control")
     );
+    
+    await wait(constants.ShortWait)
+
+    return receivedContext;
   }
 
   openChannelApp = async (testId: string, channelId: string | undefined, commands: string[], historyItems: number = undefined, notify: boolean = true) => {


### PR DESCRIPTION
- Adds extra parameter to 
```
    setupAndValidateListener1(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
    setupAndValidateListener2(channel: X | null, listenContextType: string | null, expectedContextType: string | null, errorMessage: string, onComplete: (ctx: Y) => void): void | Promise<void>;
 ```

to allow for different listen/expected

- Adds extra wait time so that we are giving enough time before deciding that we haven't seen a context.

- Removes     `validateContextIsNotReceived` since this was incorrectly implemented and added extra listeners, and the functionality is taken care of by the above two bullets.
