### PR TITLE
User channels context

### DIFF
--- a/src/mock/v1.2/channelService-1_2.ts
+++ b/src/mock/v1.2/channelService-1_2.ts
@@ -22,8 +22,9 @@ export class Fdc3CommandExecutor1_2 {
           break;
         }
         case commands.broadcastInstrumentContext: {
+          const contextType = config.contextId ? `fdc3.instrument.${config.contextId}` : "fdc3.instrument";
           this.broadcastContextItem(
-            "fdc3.instrument",
+            contextType,
             channel,
             config.historyItems,
             config.testId
@@ -31,8 +32,9 @@ export class Fdc3CommandExecutor1_2 {
           break;
         }
         case commands.broadcastContactContext: {
+          const contextType = config.contextId ? `fdc3.contact.${config.contextId}` : "fdc3.contact";
           this.broadcastContextItem(
-            "fdc3.contact",
+            contextType,
             channel,
             config.historyItems,
             config.testId

--- a/src/test/common/channel-control.ts
+++ b/src/test/common/channel-control.ts
@@ -15,7 +15,7 @@ export interface ChannelControl<X, Y> {
     closeChannelsAppWindow(testId: string): Promise<void>;
     channelCleanUp(): Promise<void>;
     unsubscribeListeners(): void | Promise<void>;
-    openChannelApp(testId: string, channelId: string | undefined, commands: string[], historyItems?: number, notify?: boolean): Promise<void>;
+    openChannelApp(testId: string, channelId: string | undefined, commands: string[], historyItems?: number, notify?: boolean, contextId?: string): Promise<void>;
   
     // listening
     initCompleteListener(testId: string): Promise<Y>
@@ -49,6 +49,7 @@ export interface AppControlContext extends CommonContext {
       historyItems: number;
       fdc3ApiVersion: string;
       channelId: string;
+      contextId?: string;
     };
   };
   
@@ -58,6 +59,7 @@ export interface AppControlContext extends CommonContext {
     notifyAppAOnCompletion?: boolean;
     historyItems?: number;
     channelId: string;
+    contextId?: string;
   };
   
   

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -17,13 +17,15 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
       it(scTestId1, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- Add fdc3.instrument context listener to app A\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
+        const contextId = cc.getRandomId();
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId1)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
-        await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST);
+        await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
         await resolveExecutionCompleteListener;
 
+        await wait(1000);
         if (!receivedContext) {
           assert.fail("No context received" + errorMessage);
         }
@@ -37,10 +39,12 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId2)
         const channel = await cc.retrieveAndJoinChannel(1);
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, () => receivedContext = true);
-        await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST);
+        const contextId = cc.getRandomId();
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
+        await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
         await resolveExecutionCompleteListener;
 
+        await wait(1000);
         if (!receivedContext) {
           assert.fail(`No context received!\n${errorMessage}`);
         }
@@ -53,12 +57,14 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId3)
         const channel = await cc.getUserChannel(1);
-        await cc.openChannelApp(scTestId3, channel.id, JOIN_AND_BROADCAST);
+        const contextId = cc.getRandomId();
+        await cc.openChannelApp(scTestId3, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
         await cc.joinChannel(channel);
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
         await resolveExecutionCompleteListener;
 
+        await wait(1000);
         if (!receivedContext) {
           assert.fail(`No context received!\n${errorMessage}`);
         }
@@ -71,11 +77,13 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId4)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, () => receivedContext = true);
+        const contextId = cc.getRandomId();
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
-        await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST);
+        await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
         await resolveExecutionCompleteListener;
 
+        await wait(1000);
         if (!receivedContext) {
           assert.fail(`No context received!\n${errorMessage}`);
         }
@@ -90,11 +98,14 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
         let contextTypes: string[] = [];
         let receivedContext = false;
 
+        const contextId = cc.getRandomId();
+
         function checkIfBothContextsReceived() {
           if (contextTypes.length === 2) {
+            console.warn(JSON.stringify(contextTypes));
             if (
-              !contextTypes.includes("fdc3.contact") ||
-              !contextTypes.includes("fdc3.instrument")
+              !contextTypes.includes(`fdc3.contact.${contextId}`) ||
+              !contextTypes.includes(`fdc3.instrument.${contextId}`)
             ) {
               assert.fail("Incorrect context received", errorMessage);
             } else {
@@ -103,20 +114,22 @@ export function createUserChannelTests(cc: ChannelControl<any,any>, documentatio
           }
         }
 
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", errorMessage, (context) => {
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         });
 
-        await cc.setupAndValidateListener2(null, "fdc3.contact", errorMessage, (context) => {
+        await cc.setupAndValidateListener2(null, `fdc3.contact.${contextId}`, errorMessage, (context) => {
           contextTypes.push(context.type);
           checkIfBothContextsReceived();
         });
 
         const channel = await cc.retrieveAndJoinChannel(1);
-        await cc.openChannelApp(scTestId5, channel.id, JOIN_AND_BROADCAST_TWICE);
+        await cc.openChannelApp(scTestId5, channel.id, JOIN_AND_BROADCAST_TWICE, undefined, true, contextId);
         await resolveExecutionCompleteListener;
 
+        await wait(2000);
+        console.warn("here");
         if (!receivedContext) {
           assert.fail(
             `At least one context was not received!\n${errorMessage}`

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -21,12 +21,11 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
       it(scTestId1, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- Add fdc3.instrument context listener to app A\r\n- App A joins channel 1\r\n- App B joins channel 1\r\n- App B broadcasts fdc3.instrument context${documentation}`;
 
-        const contextId = cc.getRandomId();
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId1)
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
-        await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
+        await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
 
         if (!receivedContext) {
@@ -42,9 +41,8 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId2)
         const channel = await cc.retrieveAndJoinChannel(1);
         let receivedContext = false;
-        const contextId = cc.getRandomId();
-        await cc.setupAndValidateListener1(null, null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
-        await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
+        await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
 
         if (!receivedContext) {
@@ -59,11 +57,10 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId3)
         const channel = await cc.getUserChannel(1);
-        const contextId = cc.getRandomId();
-        await cc.openChannelApp(scTestId3, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
+        await cc.openChannelApp(scTestId3, channel.id, JOIN_AND_BROADCAST);
         await cc.joinChannel(channel);
         let receivedContext = false;
-        await cc.setupAndValidateListener1(null, null, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, null, "fdc3.instrument", errorMessage, () => receivedContext = true);
         await resolveExecutionCompleteListener;
 
         if (!receivedContext) {
@@ -78,10 +75,9 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
 
         const resolveExecutionCompleteListener = cc.initCompleteListener(scTestId4)
         let receivedContext = false;
-        const contextId = cc.getRandomId();
-        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, `fdc3.instrument.${contextId}`, errorMessage, () => receivedContext = true);
+        await cc.setupAndValidateListener1(null, "fdc3.instrument", "fdc3.instrument", errorMessage, () => receivedContext = true);
         const channel = await cc.retrieveAndJoinChannel(1);
-        await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST, undefined, true, contextId);
+        await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST);
         await resolveExecutionCompleteListener;
 
         if (!receivedContext) {
@@ -171,8 +167,9 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
       it(scTestId8, async () => {
         const errorMessage = `\r\nSteps to reproduce:\r\n- App A adds context listener of type fdc3.instrument\r\n- App A joins channel 1\r\n- App A joins channel 2\r\n- App B joins channel 1\r\n- App B broadcasts context of type fdc3.instrument${documentation}`;
 
-        await cc.setupAndValidateListener1(null, "fdc3.instrument", "unexpected-context", errorMessage, async () => {/* noop */ });
-        await cc.setupAndValidateListener2(null, "fdc3.contact",  "unexpected-context", errorMessage, () =>  {/* noop */});
+        const contextId = cc.getRandomId();
+        await cc.setupAndValidateListener1(null, `fdc3.instrument.${contextId}`, "unexpected-context", errorMessage, async () => {/* noop */ });
+        await cc.setupAndValidateListener2(null, `fdc3.contact.${contextId}`,  "unexpected-context", errorMessage, () =>  {/* noop */});
         
         const channels = await cc.getSystemChannels();
         if (channels.length < 1) {
@@ -181,8 +178,8 @@ export function createUserChannelTests(cc: ChannelControl<any, any>, documentati
 
         await cc.joinChannel(channels[0]);
         await cc.joinChannel(channels[1]);
-        await cc.openChannelApp(scTestId8, channels[0].id, JOIN_AND_BROADCAST);
-        await wait();
+        await cc.openChannelApp(scTestId8, channels[0].id, JOIN_AND_BROADCAST, undefined, true, contextId);
+        await wait(3000);
       });
     });
   });

--- a/src/test/v1.2/advanced/channels-support-1.2.ts
+++ b/src/test/v1.2/advanced/channels-support-1.2.ts
@@ -83,12 +83,13 @@ export class ChannelControl1_2 implements ChannelControl<Channel, Context> {
     );
   }
 
-  openChannelApp = async (testId: string, channelId: string | undefined, commands: string[], historyItems: number = undefined, notify: boolean = true): Promise<void> => {
+  openChannelApp = async (testId: string, channelId: string | undefined, commands: string[], historyItems: number = undefined, notify: boolean = true, contextId?: string): Promise<void> => {
     const channelsAppConfig: ChannelsAppConfig = {
       fdc3ApiVersion: "1.2",
       testId: testId,
       channelId,
       notifyAppAOnCompletion: notify,
+      contextId
     };
 
     if (historyItems) {
@@ -268,6 +269,7 @@ function buildChannelsAppContext(
       notifyAppAOnCompletion: config.notifyAppAOnCompletion ?? false,
       historyItems: config.historyItems ?? 1,
       channelId: config.channelId,
+      contextId: config.contextId
     },
   };
 }


### PR DESCRIPTION
Add `contextId` to tests to avoid falsy test results due to replaying of addContextListener's callback with previously broadcasted data