### PR TITLE
ID only check for BasicJC2

### DIFF
--- a/src/test/v1.2/basic/fdc3.joinChannel.ts
+++ b/src/test/v1.2/basic/fdc3.joinChannel.ts
@@ -52,6 +52,6 @@ export default () =>
 
       const current = await fdc3.getCurrentChannel();
 
-      expect(current).to.eql(channel);
+      expect(current.id).to.eql(channel.id);
     })
   });


### PR DESCRIPTION
Simplifying the test for checking that joined channel is correct as a full deep compare is not needed.