### PR TITLE
Fixing sail

### DIFF
--- a/directories/local-conformance-1_2.v2.json
+++ b/directories/local-conformance-1_2.v2.json
@@ -16,7 +16,7 @@
       ],
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2"
+          "injectApi": "1.2"
         }
       },
       "version": "1.0.0",
@@ -38,7 +38,7 @@
       },
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2",
+          "injectApi": "1.2",
           "searchable": false,
           "forceNewWindow": true
         }
@@ -62,7 +62,7 @@
       },
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2",
+          "injectApi": "1.2",
           "searchable": false,
           "forceNewWindow": true
         }
@@ -105,7 +105,7 @@
       },
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2",
+          "injectApi": "1.2",
           "searchable": false,
           "forceNewWindow": true
         }
@@ -148,7 +148,7 @@
       },
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2",
+          "injectApi": "1.2",
           "searchable": false,
           "forceNewWindow": true
         }
@@ -182,7 +182,7 @@
       },
       "hostManifests": {
         "sail": {
-          "inject-api": "1.2",
+          "injectApi": "1.2",
           "searchable": false,
           "forceNewWindow": true
         }

--- a/src/test/v1.2/advanced/fdc3.raiseIntent-bad.ts
+++ b/src/test/v1.2/advanced/fdc3.raiseIntent-bad.ts
@@ -49,7 +49,7 @@ export default () =>
           },
           { name: "IntentAppA", appId: "IntentAppAId" }
         );
-        assert.fail("Error was not thrown", raiseIntentDocs);
+        assert.fail("Error was not thrown");
       } catch (ex) {
         expect(ex).to.have.property(
           "message",
@@ -70,7 +70,7 @@ export default () =>
           },
           { name: "IntentAppA" }
         );
-        assert.fail("Error was not thrown", raiseIntentDocs);
+        assert.fail("Error was not thrown");
       } catch (ex) {
         expect(ex).to.have.property(
           "message",
@@ -91,7 +91,7 @@ export default () =>
           },
           "IntentAppC"
         );
-        assert.fail("Error was not thrown", raiseIntentDocs);
+        assert.fail("Error was not thrown");
       } catch (ex) {
         expect(ex).to.have.property(
           "message",

--- a/src/test/v1.2/advanced/fdc3.raiseIntent-bad.ts
+++ b/src/test/v1.2/advanced/fdc3.raiseIntent-bad.ts
@@ -1,0 +1,239 @@
+import {
+  AppMetadata,
+  Channel,
+  Context,
+  IntentResolution,
+  Listener,
+  ResolveError,
+} from "fdc3_1_2";
+import { assert, expect } from "chai";
+import constants from "../../../constants";
+import { DesktopAgent } from "fdc3_1_2/dist/api/DesktopAgent";
+import { sleep, wait } from "../../../utils";
+import { APIDocumentation1_2 } from "../apiDocuments-1.2";
+
+declare let fdc3: DesktopAgent;
+const raiseIntentDocs =
+  "\r\nDocumentation: " + APIDocumentation1_2.raiseIntent + "\r\nCause";
+
+/**
+ * Details on the mock apps used in these tests can be found in /mock/README.md
+ */
+export default () =>
+  describe("fdc3.raiseIntent (bad)", () => {
+
+    const test5 =
+      "(FailedResolve1) Should fail to raise intent when targeted app intent-a, context 'testContextY' and intent 'aTestingIntent' do not correlate";
+    it(test5, async () => {
+      try {
+        await fdc3.raiseIntent(
+          "aTestingIntent",
+          {
+            type: "testContextY",
+          },
+          "IntentAppA"
+        );
+        assert.fail("Error was not thrown");
+      } catch (ex) {
+        expect(ex).to.have.property("message", ResolveError.NoAppsFound);
+      }
+    });
+    const test6 =
+      "(FailedResolve2) Should fail to raise intent when targeted app intent-a (name and appId), context 'testContextY' and intent 'aTestingIntent' do not correlate";
+    it(test6, async () => {
+      try {
+        await fdc3.raiseIntent(
+          "aTestingIntent",
+          {
+            type: "testContextY",
+          },
+          { name: "IntentAppA", appId: "IntentAppAId" }
+        );
+        assert.fail("Error was not thrown", raiseIntentDocs);
+      } catch (ex) {
+        expect(ex).to.have.property(
+          "message",
+          ResolveError.NoAppsFound,
+          raiseIntentDocs
+        );
+      }
+    });
+
+    const test7 =
+      "(FailedResolve3) Should fail to raise intent when targeted app intent-a (name), context 'testContextY' and intent 'aTestingIntent' do not correlate";
+    it(test7, async () => {
+      try {
+        await fdc3.raiseIntent(
+          "aTestingIntent",
+          {
+            type: "testContextY",
+          },
+          { name: "IntentAppA" }
+        );
+        assert.fail("Error was not thrown", raiseIntentDocs);
+      } catch (ex) {
+        expect(ex).to.have.property(
+          "message",
+          ResolveError.NoAppsFound,
+          raiseIntentDocs
+        );
+      }
+    });
+
+    const test8 =
+      "(FailedResolve4) Should fail to raise intent when targeted app intent-c, context 'testContextX' and intent 'aTestingIntent' do not correlate";
+    it(test8, async () => {
+      try {
+        await fdc3.raiseIntent(
+          "aTestingIntent",
+          {
+            type: "testContextX",
+          },
+          "IntentAppC"
+        );
+        assert.fail("Error was not thrown", raiseIntentDocs);
+      } catch (ex) {
+        expect(ex).to.have.property(
+          "message",
+          ResolveError.NoAppsFound,
+          raiseIntentDocs
+        );
+      }
+    });
+  });
+
+const validateIntentResolution = (
+  appName: string,
+  intentResolution: IntentResolution
+) => {
+  if (typeof intentResolution.source === "string") {
+    expect(intentResolution.source).to.eq(appName, raiseIntentDocs);
+  } else if (typeof intentResolution.source === "object") {
+    expect((intentResolution.source as AppMetadata).name).to.eq(
+      appName,
+      raiseIntentDocs
+    );
+  } else assert.fail("Invalid intent resolution object");
+};
+
+const broadcastCloseWindow = async (currentTest) => {
+  const appControlChannel = await fdc3.getOrCreateChannel(constants.ControlChannel);
+  appControlChannel.broadcast({
+    type: "closeWindow",
+    testId: currentTest,
+  } as AppControlContext);
+};
+
+// creates a channel and subscribes for broadcast contexts. This is
+// used by the 'mock app' to send messages back to the test runner for validation
+const createReceiver = async (contextType: string) => {
+  let timeout;
+  const appControlChannel = await fdc3.getOrCreateChannel(constants.ControlChannel);
+  const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    const listener = appControlChannel.addContextListener(contextType, (context) => {
+      resolve(context);
+      clearTimeout(timeout);
+      listener.unsubscribe();
+    });
+
+    //if no context received reject promise
+    const { promise: sleepPromise, timeout: theTimeout } = sleep();
+    timeout = theTimeout;
+    await sleepPromise;
+    reject(new Error("No context received from app B"));
+  });
+
+  return messageReceived;
+};
+
+async function closeIntentAppsWindows(testId) {
+  await broadcastCloseWindow(testId);
+  const appControlChannel = await fdc3.getOrCreateChannel(constants.ControlChannel);
+  await waitForContext("windowClosed", testId, appControlChannel);
+  await wait(constants.WindowCloseWaitTime);
+}
+
+const waitForContext = (
+  contextType: string,
+  testId: string,
+  channel?: Channel
+): Promise<Context> => {
+  let executionListener: Listener;
+  return new Promise<Context>(async (resolve) => {
+    console.log(
+      Date.now() +
+        ` Waiting for type: "${contextType}", on channel: "${channel.id}" in test: "${testId}"`
+    );
+
+    const handler = (context: AppControlContext) => {
+      if (testId) {
+        if (testId == context.testId) {
+          console.log(
+            Date.now() + ` Received ${contextType} for test: ${testId}`
+          );
+          resolve(context);
+          if (executionListener) executionListener.unsubscribe();
+        } else {
+          console.warn(
+            Date.now() +
+              ` Ignoring "${contextType}" context due to mismatched testId (expected: "${testId}", got "${context.testId}")`
+          );
+        }
+      } else {
+        console.log(
+          Date.now() +
+            ` Received (without testId) "${contextType}" for test: "${testId}"`
+        );
+        resolve(context);
+        if (executionListener) executionListener.unsubscribe();
+      }
+    };
+
+    if (channel === undefined) {
+      executionListener = fdc3.addContextListener(contextType, handler);
+    } else {
+      executionListener = channel.addContextListener(contextType, handler);
+      //App channels do not auto-broadcast current context when you start listening, so retrieve current context to avoid races
+      const ccHandler = async (context: AppControlContext) => {
+        if (context) {
+          if (testId) {
+            if (testId == context?.testId && context?.type == contextType) {
+              console.log(
+                Date.now() +
+                  ` Received "${contextType}" (from current context) for test: "${testId}"`
+              );
+              if (executionListener) executionListener.unsubscribe();
+              resolve(context);
+            } //do not warn as it will be ignoring mismatches which will be common
+            else {
+              console.log(
+                Date.now() +
+                  ` CHecking for current context of type "${contextType}" for test: "${testId}" Current context did ${
+                    context ? "" : "NOT "
+                  } exist, 
+had testId: "${context?.testId}" (${
+                    testId == context?.testId ? "did match" : "did NOT match"
+                  }) 
+and type "${context?.type}" (${
+                    context?.type == contextType ? "did match" : "did NOT match"
+                  })`
+              );
+            }
+          } else {
+            console.log(
+              Date.now() +
+                ` Received "${contextType}" (from current context) for an unspecified test`
+            );
+            if (executionListener) executionListener.unsubscribe();
+            resolve(context);
+          }
+        }
+      };
+      channel.getCurrentContext().then(ccHandler);
+    }
+  });
+};
+
+interface AppControlContext extends Context {
+  testId: string;
+}

--- a/src/test/v1.2/advanced/fdc3.raiseIntent-good.ts
+++ b/src/test/v1.2/advanced/fdc3.raiseIntent-good.ts
@@ -20,7 +20,7 @@ const raiseIntentDocs =
  * Details on the mock apps used in these tests can be found in /mock/README.md
  */
 export default () =>
-  describe("fdc3.raiseIntent", () => {
+  describe("fdc3.raiseIntent (good)", () => {
     afterEach(async function afterEach() {
       await closeIntentAppsWindows(this.currentTest.title);
     });
@@ -82,105 +82,6 @@ export default () =>
       );
       validateIntentResolution("IntentAppA", intentResolution);
       await result;
-    });
-
-    const test5 =
-      "(FailedResolve1) Should fail to raise intent when targeted app intent-a, context 'testContextY' and intent 'aTestingIntent' do not correlate";
-    it(test5, async () => {
-      try {
-        await fdc3.raiseIntent(
-          "aTestingIntent",
-          {
-            type: "testContextY",
-          },
-          "IntentAppA"
-        );
-        assert.fail("Error was not thrown");
-      } catch (ex) {
-        expect(ex).to.have.property("message", ResolveError.NoAppsFound);
-
-        //raise intent so that afterEach resolves
-        await fdc3.raiseIntent("sharedTestingIntent1", {
-          type: "testContextY",
-        });
-      }
-    });
-    const test6 =
-      "(FailedResolve2) Should fail to raise intent when targeted app intent-a (name and appId), context 'testContextY' and intent 'aTestingIntent' do not correlate";
-    it(test6, async () => {
-      try {
-        await fdc3.raiseIntent(
-          "aTestingIntent",
-          {
-            type: "testContextY",
-          },
-          { name: "IntentAppA", appId: "IntentAppAId" }
-        );
-        assert.fail("Error was not thrown", raiseIntentDocs);
-      } catch (ex) {
-        expect(ex).to.have.property(
-          "message",
-          ResolveError.NoAppsFound,
-          raiseIntentDocs
-        );
-
-        //raise intent so that afterEach resolves
-        await fdc3.raiseIntent("sharedTestingIntent1", {
-          type: "testContextY",
-        });
-      }
-    });
-
-    const test7 =
-      "(FailedResolve3) Should fail to raise intent when targeted app intent-a (name), context 'testContextY' and intent 'aTestingIntent' do not correlate";
-    it(test7, async () => {
-      try {
-        await fdc3.raiseIntent(
-          "aTestingIntent",
-          {
-            type: "testContextY",
-          },
-          { name: "IntentAppA" }
-        );
-        assert.fail("Error was not thrown", raiseIntentDocs);
-      } catch (ex) {
-        expect(ex).to.have.property(
-          "message",
-          ResolveError.NoAppsFound,
-          raiseIntentDocs
-        );
-
-        //raise intent so that afterEach resolves
-        await fdc3.raiseIntent("sharedTestingIntent1", {
-          type: "testContextY",
-        });
-      }
-    });
-
-    const test8 =
-      "(FailedResolve4) Should fail to raise intent when targeted app intent-c, context 'testContextX' and intent 'aTestingIntent' do not correlate";
-    it(test8, async () => {
-      try {
-        await fdc3.raiseIntent(
-          "aTestingIntent",
-          {
-            type: "testContextX",
-          },
-          "IntentAppC"
-        );
-        assert.fail("Error was not thrown", raiseIntentDocs);
-      } catch (ex) {
-        expect(ex).to.have.property(
-          "message",
-          ResolveError.NoAppsFound,
-          raiseIntentDocs
-        );
-
-        //raise intent so that afterEach resolves
-        await fdc3.raiseIntent("sharedTestingIntent1", {
-          type: "testContextY",
-        });
-      }
     });
   });
 

--- a/src/test/v1.2/testSuite.ts
+++ b/src/test/v1.2/testSuite.ts
@@ -14,7 +14,8 @@ import fdc3GetSystemChannels_1_2 from "./basic/fdc3.getSystemChannels";
 import fdc3JoinChannel_1_2 from "./basic/fdc3.joinChannel";
 import fdc3LeaveCurrentChannel_1_2 from "./basic/fdc3.leaveCurrentChannel";
 import fdc3Open_1_2 from "./advanced/fdc3.open";
-import fdc3RaiseIntent_1_2 from "./advanced/fdc3.raiseIntent";
+import fdc3RaiseIntent_1_2_Bad from "./advanced/fdc3.raiseIntent-bad";
+import fdc3RaiseIntent_1_2_Good from "./advanced/fdc3.raiseIntent-good";
 import fdc3RaiseIntentForContext_1_2 from "./basic/fdc3.raiseIntentForContext";
 
 type testSet = { [key: string]: (() => void)[] };
@@ -36,7 +37,8 @@ const advancedSuite_1_2: testSet = {
   fdc3AppChannels_1_2: [fdc3AppChannels_1_2],
   fdc3UserChannels_1_2: [fdc3UserChannels_1_2],
   fdc3FindIntent_1_2: [fdc3FindIntent_1_2],
-  fdc3RaiseIntent_1_2: [fdc3RaiseIntent_1_2],
+  fdc3RaiseIntent_1_2_Bad: [fdc3RaiseIntent_1_2_Bad],
+  fdc3RaiseIntent_1_2_Good: [fdc3RaiseIntent_1_2_Good],
   fdc3FindIntentsByContext_1_2: [fdc3FindIntentsByContext_1_2],
 };
 


### PR DESCRIPTION
- Fixed the local manifest so that sail apps are injected with the 1.2 API
- Separated out raise intent code into two sections: ones that correctly raise and intent and ones that don't.  This fixes a really poor piece of implementation in the code since the intents that don't raise then go on to open an app so that the afterEach can close down a window!   This was causing lots of race conditions