### PR TITLE
fix test title & timeout error

### DIFF
--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -10,9 +10,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
     beforeEach(cc.leaveChannel);
 
     afterEach(async function afterEach() {
-      if (this.currentTest.title !== UCFilteredUsageLeave) {
-        await cc.closeMockApp(this.currentTest.title);
-      }
+      if (this.currentTest.title !== UCFilteredUsageJoin) await cc.closeMockApp(this.currentTest.title);
     });
 
     const scTestId1 = "(" + prefix + "UCBasicUsage1) Should receive context when adding a listener then joining a user channel before app B broadcasts context to the same channel";
@@ -278,7 +276,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       cc.unsubscribeListeners([listener, listener2]);
     });
 
-    const UCFilteredUsageJoin = "(" + prefix + "UCFilteredUsageLeave) Should not receive context after leaving a user channel";
+    const UCFilteredUsageJoin = "(" + prefix + "UCFilteredUsageJoin) getCurrentChannel retrieves the channel that was joined";
     it(UCFilteredUsageJoin, async () => {
       const errorMessage = `\r\nSteps to reproduce:\r\n- App A retrieves user channels\r\n- App A joins the third channel\r\n- App A gets current channel${documentation}`;
       const channels = await cc.getSystemChannels();


### PR DESCRIPTION
This PR addresses this issue: https://github.com/finos/FDC3-conformance-framework/issues/169

**Changes:**

- `UCFilteredUsageJoin` test was already there, it just had the wrong title which I've now amended
- `UCFilteredUsageNoJoin` is a duplicate of `BasicCH2` so we need to remove `UCFilteredUsageNoJoin` from the test definitions
- Bug fix: UCFilteredUsageJoin was timing out when run as a single test due to the after each waiting for the mock app window to close. This particular test does not open a mock app and this was causing the test to timeout.