### PR TITLE
Update Finsemble 1.2 manifests

### DIFF
--- a/directories/local-conformance-1_2.v2.json
+++ b/directories/local-conformance-1_2.v2.json
@@ -37,7 +37,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -83,7 +84,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -127,6 +129,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -189,6 +195,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -251,6 +261,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -306,7 +320,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },


### PR DESCRIPTION
Adding a config flag necessary for 1.2 conformance, supported from Finsemble 8.6.0 onwards.

@gaganahluwalia when testing this, make sure you update your seed project to latest first and reinstall the node modules so that you are running the relevant version.

Use of the flag seems to resolve all 4 issues for me: 
![image](https://user-images.githubusercontent.com/1701764/229126644-cc6e7834-c75d-485a-b3ec-91d4421ebac0.png)
