### PR TITLE
Update local-conformance-1_2.v2.json to restore fdc3 1.2 compatable config

### DIFF
--- a/directories/local-conformance-1_2.v2.json
+++ b/directories/local-conformance-1_2.v2.json
@@ -37,7 +37,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -83,7 +84,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -127,6 +129,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -189,6 +195,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -251,6 +261,10 @@
                       "titlebarType": "injected"
                   }
               }
+          },
+          "interop": {
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },
@@ -306,7 +320,8 @@
               }
           },
           "interop": {
-            "joinMultipleChannels": false
+            "joinMultipleChannels": false,
+            "fdc3_1_2_compatibility": true
           }
         }
       },


### PR DESCRIPTION
Release candidate branch is reverting some necessary config in the FInsemble hostManifest