### PR TITLE
Make tests more robust on lower performance machines

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,9 +4,9 @@
 const constants = {
   ShortWait: 1000,
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
-  TestTimeout: 15000, // Tests that take longer than this (in milliseconds) will fail
-  WaitTime: 3000, // The amount of time to wait for mock apps to finish processing
-  WindowCloseWaitTime: 750, // The amount of time to allow for clean-up of closed windows
+  TestTimeout: 20000, // Tests that take longer than this (in milliseconds) will fail
+  WaitTime: 5000, // The amount of time to wait for mock apps to finish processing
+  WindowCloseWaitTime: 1000, // The amount of time to allow for clean-up of closed windows
   NoListenerTimeout: 120000, // the amount of time to allow for a DA to timeout waiting on a context or intent listener
   // FDC3 does not define this timeout so this should be extended if the DA uses a longer timeout
   ControlChannel: "app-control", //app channel used for passing messages between mock apps and tests

--- a/src/test/common/fdc3.app-channels.ts
+++ b/src/test/common/fdc3.app-channels.ts
@@ -22,9 +22,16 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       });
       await cc.openChannelApp(acTestId, testChannel.id, APP_CHANNEL_AND_BROADCAST);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener1]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener1]);
       }
     });
 
@@ -40,7 +47,11 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       await cc.setupContextChecker(testChannel, null, "fdc3.instrument", errorMessage, () => (receivedContext = true));
 
       if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+        //allow upto a second for the context to arrive
+        await wait(1000);
+        if (!receivedContext) {
+          assert.fail(`No context received!\n${errorMessage}`);
+        }
       }
     });
 
@@ -56,9 +67,16 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       });
       await cc.openChannelApp(acTestId4, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener1]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener1]);
       }
     });
 
@@ -109,9 +127,16 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       });
       await cc.openChannelApp(acTestId8, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener, listener2]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener, listener2]);
       }
     });
 
@@ -132,9 +157,16 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       });
       await cc.openChannelApp(acTestId9, testChannel.id, APP_CHANNEL_AND_BROADCAST_TWICE);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener, listener2]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener,listener2]);
       }
     });
 

--- a/src/test/common/fdc3.app-channels.ts
+++ b/src/test/common/fdc3.app-channels.ts
@@ -1,5 +1,6 @@
 import { assert, expect } from "chai";
 import { wait } from "../../utils";
+import constants from "../../constants";
 import { APP_CHANNEL_AND_BROADCAST, APP_CHANNEL_AND_BROADCAST_TWICE, ChannelControl, JOIN_AND_BROADCAST_TWICE } from "./control/channel-control";
 
 export function createAppChannelTests(cc: ChannelControl<any, any, any>, documentation: string, prefix: string): Mocha.Suite {
@@ -25,7 +26,7 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -48,7 +49,7 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
 
       if (!receivedContext) {
         //allow upto a second for the context to arrive
-        await wait(1000);
+        await wait(constants.ShortWait);
         if (!receivedContext) {
           assert.fail(`No context received!\n${errorMessage}`);
         }
@@ -70,7 +71,7 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -130,7 +131,7 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -160,7 +161,7 @@ export function createAppChannelTests(cc: ChannelControl<any, any, any>, documen
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -2,6 +2,7 @@ import { assert, expect } from "chai";
 import { failOnTimeout, wait, wrapPromise } from "../../utils";
 import { JOIN_AND_BROADCAST, JOIN_AND_BROADCAST_TWICE } from "./control/channel-control";
 import { ChannelControl } from "./control/channel-control";
+import constants from "../../constants";
 
 export function createUserChannelTests(cc: ChannelControl<any, any, any>, documentation: string, prefix: string): Mocha.Suite {
   const channelName = prefix === "" ? "System channels" : "User channels";
@@ -23,9 +24,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       await cc.joinChannel(channel);
       await cc.openChannelApp(scTestId1, channel.id, JOIN_AND_BROADCAST);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail("No context received" + errorMessage);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -40,9 +48,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let listener = await cc.setupAndValidateListener(null, null, "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await cc.openChannelApp(scTestId2, channel.id, JOIN_AND_BROADCAST);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -57,9 +72,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let listener = await cc.setupAndValidateListener(null, null, "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await cc.joinChannel(channel);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -74,9 +96,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let receivedContext = false;
       let listener = await cc.setupAndValidateListener(null, null, "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -91,9 +120,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       await cc.joinChannel(channel);
       await cc.openChannelApp(scTestId4, channel.id, JOIN_AND_BROADCAST_TWICE);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -108,9 +144,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let listener = await cc.setupAndValidateListener(null, "fdc3.instrument", "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await cc.openChannelApp(UCFilteredUsage2, channel.id, JOIN_AND_BROADCAST_TWICE);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -125,9 +168,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let listener = await cc.setupAndValidateListener(null, "fdc3.instrument", "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await cc.joinChannel(userChannel);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -142,9 +192,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       let receivedContext = false;
       let listener = await cc.setupAndValidateListener(undefined, "fdc3.instrument", "fdc3.instrument", errorMessage, () => (receivedContext = true));
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener]);
-      if (!receivedContext) {
-        assert.fail(`No context received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener]);
       }
     });
 
@@ -181,9 +238,16 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       await cc.joinChannel(channel);
       await cc.openChannelApp(scTestId5, channel.id, JOIN_AND_BROADCAST_TWICE, undefined, true, contextId);
       await resolveExecutionCompleteListener;
-      cc.unsubscribeListeners([listener, listener2]);
-      if (!receivedContext) {
-        assert.fail(`At least one context was not received!\n${errorMessage}`);
+      try {
+        if (!receivedContext) {
+          //allow upto a second for the context to arrive
+          await wait(1000);
+          if (!receivedContext) {
+            assert.fail(`No context received!\n${errorMessage}`);
+          }
+        }
+      } finally {
+        cc.unsubscribeListeners([listener, listener2]);
       }
     });
 

--- a/src/test/common/fdc3.user-channels.ts
+++ b/src/test/common/fdc3.user-channels.ts
@@ -27,7 +27,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -51,7 +51,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -75,7 +75,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -99,7 +99,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -123,7 +123,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -147,7 +147,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -171,7 +171,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -195,7 +195,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }
@@ -241,7 +241,7 @@ export function createUserChannelTests(cc: ChannelControl<any, any, any>, docume
       try {
         if (!receivedContext) {
           //allow upto a second for the context to arrive
-          await wait(1000);
+          await wait(constants.ShortWait);
           if (!receivedContext) {
             assert.fail(`No context received!\n${errorMessage}`);
           }


### PR DESCRIPTION
resolves #241 

Add short waits to basic channel tests to allow context to arrive on lower-performance machines, which may be more prone to race conditions.