### PR TITLE
Fix error in 2.0 findInstances validation function

### DIFF
--- a/src/test/v2.0/advanced/fdc3.findInstances.ts
+++ b/src/test/v2.0/advanced/fdc3.findInstances.ts
@@ -5,6 +5,7 @@ import { closeMockAppWindow } from "../fdc3-2_0-utils";
 import { IntentUtilityContext } from "../../../context-types";
 import { MetadataFdc3Api } from "../support/metadata-support-2.0";
 import { ContextType, Intent, IntentApp, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
+import { AppIdentifier, IntentResolution } from "fdc3_2_0";
 
 const findInstancesDocs = "\r\nDocumentation: " + APIDocumentation2_0.findInstances + "\r\nCause: ";
 
@@ -54,15 +55,18 @@ export default () =>
     });
   });
 
-function validateResolutionSource(resolution, appIdentifier) {
+function validateResolutionSource(resolution: IntentResolution, appIdentifier: AppIdentifier) {
   // check that resolution.source matches the appIdentifier
   expect(resolution.source.appId, "IntentResolution.source.appId did not match the mock app's AppIdentifier's appId").to.be.equal(appIdentifier.appId);
   expect(resolution.source.instanceId, "IntentResolution.source.instanceId did not match the mock app's AppIdentifier's instanceId").to.be.equal(appIdentifier.instanceId);
 }
 
-function validateInstances(instances, appIdentifier, appIdentifier2) {
-  // check that the retrieved instances match the retrieved appIdentifiers
-  if (!instances.some((instance) => JSON.stringify(instance) === JSON.stringify(appIdentifier) || JSON.stringify(instance) === JSON.stringify(appIdentifier2))) {
+function validateInstances(instances: AppIdentifier[], appIdentifier: AppIdentifier, appIdentifier2: AppIdentifier) {
+  // check that the retrieved instances match both the retrieved appIdentifiers
+  const compareAppIdentifiers = (a: AppIdentifier, b: AppIdentifier) => a.appId === b.appId && a.instanceId === b.instanceId;
+
+  if (!(instances.some((instance) => compareAppIdentifiers(instance, appIdentifier)) &&
+       instances.some((instance) => compareAppIdentifiers(instance, appIdentifier2)))) {
     assert.fail(`At least one AppIdentifier object is missing from the AppIdentifier array returned after calling fdc3.findInstances(app: AppIdentifier)${findInstancesDocs}`);
   }
 }


### PR DESCRIPTION
The existing check was incorrect in a couple of ways:
1. It wasn't checking that both `AppIdentifiers` were present, only that either was
2. `JSON.stringify` doesn't guarantee the ordering of parameters in the stringified object, the order they were added when creating the object affects the order in which they stringify, hence, two objects with identical properties may not produce equal strings.

Added typing to utility functions - its typescript after all!