### PR TITLE
Fix intent channel result tests, a couple of app definitions and use of magic strings

### DIFF
--- a/directories/local-conformance-2_0.v2.json
+++ b/directories/local-conformance-2_0.v2.json
@@ -47,7 +47,7 @@
 			"interop": {
 				"intents": {
 					"listensFor": {
-						"fdc3.conformanceListener": {
+						"ConformanceListener": {
 							"contexts": ["fdc3.nothing"]
 						}
 					}

--- a/directories/local-conformance-2_0.v2.json
+++ b/directories/local-conformance-2_0.v2.json
@@ -180,10 +180,6 @@
 			"interop": {
 				"intents": {
 					"listensFor": {
-						"bTestingIntent": {
-							"displayName": "B Testing Intent",
-							"contexts": ["testContextY"]
-						},
 						"sharedTestingIntent1": {
 							"displayName": "Shared Testing Intent",
 							"contexts": ["testContextX", "testContextY"],

--- a/directories/local-conformance-2_0.v2.json
+++ b/directories/local-conformance-2_0.v2.json
@@ -1,5 +1,6 @@
 {
-	"applications": [{
+	"applications": [
+		{
 			"appId": "Conformance1",
 			"name": "Conformance1",
 			"title": "FDC3 2.0 Conformance Framework",
@@ -42,7 +43,16 @@
 			"publisher": "FINOS",
 			"icons": [{
 				"src": "http://localhost:3001/finos-icon-256.png"
-			}]
+			}],
+			"interop": {
+				"intents": {
+					"listensFor": {
+						"fdc3.conformanceListener": {
+							"contexts": ["fdc3.nothing"]
+						}
+					}
+				}
+			}
 		},
 		{
 			"appId": "ChannelsAppId",

--- a/options/glue/v2.0/glue42/core-plus/startCorePlusRunner.js
+++ b/options/glue/v2.0/glue42/core-plus/startCorePlusRunner.js
@@ -54,11 +54,6 @@ const init = async () => {
                     },
                     intents: [
                         {
-                            name: "bTestingIntent",
-                            displayName: "B Testing Intent",
-                            contexts: ["testContextY"],
-                        },
-                        {
                             name: "sharedTestingIntent1",
                             displayName: "Shared Testing Intent",
                             contexts: ["testContextX", "testContextY"],

--- a/options/glue/v2.0/glue42/startRunner.js
+++ b/options/glue/v2.0/glue42/startRunner.js
@@ -53,11 +53,6 @@ const init = async () => {
                     },
                     intents: [
                         {
-                            name: "bTestingIntent",
-                            displayName: "B Testing Intent",
-                            contexts: ["testContextY"],
-                        },
-                        {
                             name: "sharedTestingIntent1",
                             displayName: "Shared Testing Intent",
                             contexts: ["testContextX", "testContextY"],

--- a/src/mock/v2.0/basic.ts
+++ b/src/mock/v2.0/basic.ts
@@ -2,7 +2,7 @@ import { closeWindowOnCompletion, onFdc3Ready } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { sendContextToTests } from "./mock-functions";
 import { AppControlContext } from "../../context-types";
-import { Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 declare let fdc3: DesktopAgent;
 onFdc3Ready().then(async () => {
   await closeWindowOnCompletion();
@@ -12,14 +12,14 @@ onFdc3Ready().then(async () => {
       // broadcast that this app has received context
       if (context.type === "fdc3.instrument") {
         await sendContextToTests({
-          type: "context-received",
+          type: ControlContextType.contextReceived,
           context: context,
         } as AppControlContext);
       }
     });
   } catch (ex) {
     await sendContextToTests({
-      type: "context-received",
+      type: ControlContextType.contextReceived,
       errorMessage: `${ex.message ?? ex}`,
     } as AppControlContext);
   }

--- a/src/mock/v2.0/intent-a.ts
+++ b/src/mock/v2.0/intent-a.ts
@@ -3,7 +3,7 @@ import { sendContextToTests } from "../v2.0/mock-functions";
 import { wait } from "../../utils";
 import { IntentUtilityContext } from "../../context-types";
 import { IntentResult, DesktopAgent } from "fdc3_2_0";
-import { ContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 declare let fdc3: DesktopAgent;
 
 onFdc3Ready().then(async () => {
@@ -17,7 +17,7 @@ onFdc3Ready().then(async () => {
     const { appMetadata } = await fdc3.getInfo();
 
     await sendContextToTests({
-      type: "aTestingIntent-listener-triggered",
+      type: ControlContextType.aTestingIntentListenerTriggered,
       instanceId: appMetadata.instanceId,
     });
 
@@ -29,14 +29,14 @@ onFdc3Ready().then(async () => {
     await delayExecution(context.delayBeforeReturn);
 
     await sendContextToTests({
-      type: "sharedTestingIntent1-listener-triggered",
+      type: ControlContextType.sharedTestingIntent1ListenerTriggered,
     });
 
     return context;
   });
 
   await sendContextToTests({
-    type: "intent-app-a-opened",
+    type: ControlContextType.intentAppAOpened,
   });
 });
 

--- a/src/mock/v2.0/intent-b.ts
+++ b/src/mock/v2.0/intent-b.ts
@@ -3,7 +3,7 @@ import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { sendContextToTests } from "../v2.0/mock-functions";
 import { wait } from "../../utils";
 import { AppControlContext, IntentUtilityContext } from "../../context-types";
-import { Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 declare let fdc3: DesktopAgent;
 onFdc3Ready().then(async () => {
   await closeWindowOnCompletion();
@@ -14,14 +14,14 @@ onFdc3Ready().then(async () => {
       // broadcast that this app has received context
       if (context.type === "fdc3.instrument") {
         await sendContextToTests({
-          type: "context-received",
+          type: ControlContextType.contextReceived,
           context: context,
         } as AppControlContext);
       }
     });
   } catch (ex) {
     await sendContextToTests({
-      type: "context-received",
+      type: ControlContextType.contextReceived,
       errorMessage: `${ex.message ?? ex}`,
     } as AppControlContext);
   }
@@ -33,7 +33,7 @@ onFdc3Ready().then(async () => {
     }
 
     await sendContextToTests({
-      type: "sharedTestingIntent1-listener-triggered",
+      type: ControlContextType.sharedTestingIntent1ListenerTriggered,
     });
 
     return context;

--- a/src/mock/v2.0/intent-c.ts
+++ b/src/mock/v2.0/intent-c.ts
@@ -2,7 +2,7 @@ import { closeWindowOnCompletion, onFdc3Ready } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { sendContextToTests } from "../v2.0/mock-functions";
 import { AppControlContext } from "../../context-types";
-import { Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 declare let fdc3: DesktopAgent;
 onFdc3Ready().then(async () => {
   await closeWindowOnCompletion();
@@ -12,14 +12,14 @@ onFdc3Ready().then(async () => {
       // broadcast that this app has received context
       if (context.type === "fdc3.instrument") {
         await sendContextToTests({
-          type: "context-received",
+          type: ControlContextType.contextReceived,
           context: context,
         } as AppControlContext);
       }
     });
   } catch (ex) {
     await sendContextToTests({
-      type: "context-received",
+      type: ControlContextType.contextReceived,
       errorMessage: `${ex.message ?? ex}`,
     } as AppControlContext);
   }

--- a/src/mock/v2.0/intent-e.ts
+++ b/src/mock/v2.0/intent-e.ts
@@ -1,21 +1,25 @@
 import { closeWindowOnCompletion, onFdc3Ready, sendContextToTests, validateContext } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0";
 import { wait } from "../../utils";
-import { ContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import constants from "../../constants";
 
 declare let fdc3: DesktopAgent;
 
 //used in '2.0-RaiseIntentChannelResult'
 onFdc3Ready().then(async () => {
   await closeWindowOnCompletion();
+  const { appMetadata } = await fdc3.getInfo();
+  
   fdc3.addIntentListener(Intent.sharedTestingIntent2, async (context) => {
     validateContext(context.type, ContextType.testContextY);
     const channel = await fdc3.getOrCreateChannel("test-channel");
+    
+    //set-up alert to test framework that the task was completed after a short delay
+    setTimeout(async () => {
+      await sendContextToTests({ type: ControlContextType.sharedTestingIntent2ResultSent, id: { key: "uniqueId" }, instanceId: appMetadata.instanceId });
+    }, constants.ShortWait)
+    
     return channel;
   });
-
-  const { appMetadata } = await fdc3.getInfo();
-
-  await wait(); // send context after short delay
-  await sendContextToTests({ type: ContextType.testContextZ, id: { key: "uniqueId" }, instanceId: appMetadata.instanceId });
 });

--- a/src/mock/v2.0/intent-f.ts
+++ b/src/mock/v2.0/intent-f.ts
@@ -1,20 +1,24 @@
 import { closeWindowOnCompletion, onFdc3Ready, sendContextToTests, validateContext } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0";
 import { wait } from "../../utils";
-import { ContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import constants from "../../constants";
 declare let fdc3: DesktopAgent;
 
 //used in '2.0-RaiseIntentPrivateChannelResult'
 onFdc3Ready().then(async () => {
   await closeWindowOnCompletion();
+  const { appMetadata } = await fdc3.getInfo();
+
   fdc3.addIntentListener(Intent.sharedTestingIntent2, async (context) => {
     validateContext(context.type, ContextType.testContextY);
     const privateChannel = await fdc3.createPrivateChannel();
+
+    //set-up alert to test framework that the task was completed after a short delay
+    setTimeout(async () => {
+      await sendContextToTests({ type: ControlContextType.sharedTestingIntent2ResultSent, id: { key: "uniqueId" }, instanceId: appMetadata.instanceId });
+    }, constants.ShortWait)
+    
     return privateChannel;
   });
-
-  const { appMetadata } = await fdc3.getInfo();
-
-  await wait(); // send context after short delay
-  await sendContextToTests({ type: ContextType.testContextZ, id: { key: "uniqueId" }, instanceId: appMetadata.instanceId });
 });

--- a/src/mock/v2.0/intent-j.ts
+++ b/src/mock/v2.0/intent-j.ts
@@ -1,6 +1,6 @@
 import { closeWindowOnCompletion, onFdc3Ready, sendContextToTests, validateContext } from "./mock-functions";
 import { ChannelError, DesktopAgent } from "fdc3_2_0";
-import { ContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 
 declare let fdc3: DesktopAgent;
 
@@ -13,10 +13,10 @@ onFdc3Ready().then(async () => {
 
     try {
       await fdc3.getOrCreateChannel(context.id.key);
-      await sendContextToTests({ type: "error", errorMessage: "No error thrown when calling fdc3.getOrCreateChannel('<idPassedInContext>') from the mock app" });
+      await sendContextToTests({ type: ControlContextType.error, errorMessage: "No error thrown when calling fdc3.getOrCreateChannel('<idPassedInContext>') from the mock app" });
     } catch (ex) {
       if (ex.message !== ChannelError.AccessDenied) {
-        await sendContextToTests({ type: "error", errorMessage: `Incorrect error received when calling fdc3.getOrCreateChannel('<idPassedInContext>'). Expected AccessDenied, got ${ex.message}` });
+        await sendContextToTests({ type: ControlContextType.error, errorMessage: `Incorrect error received when calling fdc3.getOrCreateChannel('<idPassedInContext>'). Expected AccessDenied, got ${ex.message}` });
       }
     }
 

--- a/src/mock/v2.0/intent-k.ts
+++ b/src/mock/v2.0/intent-k.ts
@@ -3,7 +3,7 @@ import { DesktopAgent } from "fdc3_2_0";
 import { wait } from "../../utils";
 import { IntentUtilityContext } from "../../context-types";
 import constants from "../../constants";
-import { ContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 declare let fdc3: DesktopAgent;
 
 //used in '2.0-PrivateChannelsLifecycleEvents'
@@ -39,12 +39,12 @@ onFdc3Ready().then(async () => {
 
     await privChan.onUnsubscribe(async (contextType) => {
       //let test know onUnsubscribe was triggered
-      await sendContextToTests({ type: "onUnsubscribeTriggered" });
+      await sendContextToTests({ type: ControlContextType.onUnsubscribeTriggered });
     });
 
     await privChan.onDisconnect(async () => {
       //let test know onUnsubscribe was triggered
-      await sendContextToTests({ type: "onDisconnectTriggered" });
+      await sendContextToTests({ type: ControlContextType.onDisconnectTriggered });
     });
 
     return privChan;

--- a/src/mock/v2.0/metadata.ts
+++ b/src/mock/v2.0/metadata.ts
@@ -19,16 +19,4 @@ onFdc3Ready().then(async () => {
 
     sendContextToTests(metadataContext);
   });
-
-  // used in 'FindInstances'
-  await fdc3.addIntentListener(Intent.aTestingIntent, async (context) => {
-    const implMetadata = await fdc3.getInfo();
-    const metadataAppContext: AppControlContext = {
-      type: ControlContextType.IntentListenerTriggered,
-      instanceId: implMetadata.appMetadata.instanceId,
-    };
-
-    sendContextToTests(metadataAppContext);
-    return context;
-  });
 });

--- a/src/mock/v2.0/metadata.ts
+++ b/src/mock/v2.0/metadata.ts
@@ -1,7 +1,7 @@
 import { closeWindowOnCompletion, onFdc3Ready, sendContextToTests } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0";
 import { AppControlContext } from "../../context-types";
-import { Intent } from "../../test/v2.0/support/intent-support-2.0";
+import { ControlContextType, Intent } from "../../test/v2.0/support/intent-support-2.0";
 
 declare let fdc3: DesktopAgent;
 
@@ -13,7 +13,7 @@ onFdc3Ready().then(async () => {
     //execute command from test app and send back metadata
     const implMetadata = await fdc3.getInfo();
     const metadataContext = {
-      type: "context-listener-triggered",
+      type: ControlContextType.ContextListenerTriggered,
       implMetadata: implMetadata,
     };
 
@@ -24,7 +24,7 @@ onFdc3Ready().then(async () => {
   await fdc3.addIntentListener(Intent.aTestingIntent, async (context) => {
     const implMetadata = await fdc3.getInfo();
     const metadataAppContext: AppControlContext = {
-      type: "intent-listener-triggered",
+      type: ControlContextType.IntentListenerTriggered,
       instanceId: implMetadata.appMetadata.instanceId,
     };
 

--- a/src/mock/v2.0/open-a.ts
+++ b/src/mock/v2.0/open-a.ts
@@ -2,6 +2,7 @@ import { closeWindowOnCompletion, onFdc3Ready } from "./mock-functions";
 import { DesktopAgent } from "fdc3_2_0/dist/api/DesktopAgent";
 import { sendContextToTests } from "../v2.0/mock-functions";
 import { AppControlContext } from "../../context-types";
+import { ControlContextType } from "../../test/v2.0/support/intent-support-2.0";
 
 declare let fdc3: DesktopAgent;
 onFdc3Ready().then(async () => {
@@ -10,7 +11,7 @@ onFdc3Ready().then(async () => {
     // broadcast that this app has received context
     if (context.type !== "shouldNotReceiveThisContext") {
       await sendContextToTests({
-        type: "context-received",
+        type: ControlContextType.contextReceived,
         errorMessage: `Listener received incorrect context type. Listener listening for 'shouldNotReceiveThisContext' type received '${context.type}' type`,
       } as AppControlContext);
     }

--- a/src/test/common/fdc3.basic.ts
+++ b/src/test/common/fdc3.basic.ts
@@ -41,7 +41,7 @@ export let basicCL2 = (fdc3: any, documentation: string, listener: any) => {
 
 export let basicIL1 = (fdc3: any, documentation: string, listener: any) => {
   it("(BasicIL1) Method is callable", async () => {
-    const intentName = "fdc3.conformanceListener";
+    const intentName = "ConformanceListener";
     try {
       listener = await fdc3.addIntentListener(intentName, (info: any) => {
         console.log(`Intent listener for intent ${intentName} triggered with result ${info}`);

--- a/src/test/common/fdc3.open.ts
+++ b/src/test/common/fdc3.open.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import constants from "../../constants";
 import { openApp, OpenCommonConfig, OpenControl } from "./control/open-control";
+import { ControlContextType } from "../v2.0/support/intent-support-2.0";
 
 export function getCommonOpenTests(control: OpenControl<any>, documentation: string, config: OpenCommonConfig) {
 
@@ -31,7 +32,7 @@ export function getCommonOpenTests(control: OpenControl<any>, documentation: str
     let context: any, targetApp: any;
     context = { type: "fdc3.instrument", name: "context" };
     targetApp = control.createTargetApp(openApp.b.name,openApp.b.id);
-    const receiver = control.contextReceiver("context-received");
+    const receiver = control.contextReceiver(ControlContextType.contextReceived);
     await control.openMockApp(targetApp, context);
     await control.validateReceivedContext(await receiver, "fdc3.instrument");
     await control.closeMockApp(AOpensBWithContext3);
@@ -42,7 +43,7 @@ export function getCommonOpenTests(control: OpenControl<any>, documentation: str
     let context: any, targetApp: any;
     context = { type: "fdc3.instrument", name: "context" };
     targetApp = control.createTargetApp(openApp.b.name,openApp.b.id);
-    const receiver = control.contextReceiver("context-received");
+    const receiver = control.contextReceiver(ControlContextType.contextReceived);
     await control.openMockApp(targetApp, context);
     await control.validateReceivedContext(await receiver, "fdc3.instrument");
     await control.closeMockApp(AOpensBWithSpecificContext);
@@ -53,7 +54,7 @@ export function getCommonOpenTests(control: OpenControl<any>, documentation: str
     let context: any, targetApp: any;
     context = { type: "fdc3.instrument", name: "context" };
     targetApp = control.createTargetApp(openApp.b.name,openApp.b.id);
-    const receiver = control.contextReceiver("context-received");
+    const receiver = control.contextReceiver(ControlContextType.contextReceived);
     await control.openMockApp(targetApp, context);
     await receiver;
     await control.validateReceivedContext(await receiver, "fdc3.instrument");

--- a/src/test/v2.0/advanced/fdc3.findInstances.ts
+++ b/src/test/v2.0/advanced/fdc3.findInstances.ts
@@ -4,7 +4,7 @@ import { failOnTimeout, wrapPromise } from "../../../utils";
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
 import { IntentUtilityContext } from "../../../context-types";
 import { MetadataFdc3Api } from "../support/metadata-support-2.0";
-import { ContextType, Intent, IntentApp, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent, IntentApp, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
 
 const findInstancesDocs = "\r\nDocumentation: " + APIDocumentation2_0.findInstances + "\r\nCause: ";
 
@@ -30,12 +30,12 @@ export default () =>
         let instances = await control.findInstances(IntentApp.IntentAppA);
         validateInstances(instances, appIdentifier, appIdentifier2);
 
-        const timeout = failOnTimeout("'aTestingIntent-listener-triggered' context not received from mock app"); // fail if expected context not received
+        const timeout = failOnTimeout(`'${ControlContextType.aTestingIntentListenerTriggered}' context not received from mock app`); // fail if expected context not received
         const wrapper = wrapPromise();
         const appControlChannel = await api.retrieveAppControlChannel();
 
         //ensure appIdentifier received the raised intent
-        listener = await appControlChannel.addContextListener("aTestingIntent-listener-triggered", (context: IntentUtilityContext) => {
+        listener = await appControlChannel.addContextListener(ControlContextType.aTestingIntentListenerTriggered, (context: IntentUtilityContext) => {
           expect(context['instanceId'], "the raised intent was received by a different instance of the mock app than expected").to.be.equals(appIdentifier.instanceId);
           clearTimeout(timeout);
           wrapper.resolve();

--- a/src/test/v2.0/advanced/fdc3.findInstances.ts
+++ b/src/test/v2.0/advanced/fdc3.findInstances.ts
@@ -4,7 +4,7 @@ import { failOnTimeout, wrapPromise } from "../../../utils";
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
 import { IntentUtilityContext } from "../../../context-types";
 import { MetadataFdc3Api } from "../support/metadata-support-2.0";
-import { ContextType, Intent, IntentApp, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
+import { ContextType, ControlContextType, Intent, IntentApp, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
 import { AppIdentifier, IntentResolution } from "fdc3_2_0";
 
 const findInstancesDocs = "\r\nDocumentation: " + APIDocumentation2_0.findInstances + "\r\nCause: ";

--- a/src/test/v2.0/advanced/fdc3.getInfo.ts
+++ b/src/test/v2.0/advanced/fdc3.getInfo.ts
@@ -4,6 +4,7 @@ import { closeMockAppWindow } from "../fdc3-2_0-utils";
 import { ImplementationMetadata, Listener } from "fdc3_2_0";
 import { MetadataValidator, MetadataContext, MetadataFdc3Api } from "../support/metadata-support-2.0";
 import { APIDocumentation2_0 } from "../apiDocuments-2.0";
+import { ControlContextType } from "../support/intent-support-2.0";
 
 const getInfoDocs = "\r\nDocumentation: " + APIDocumentation2_0.getInfo + "\r\nCause";
 const validator = new MetadataValidator();
@@ -46,7 +47,7 @@ export default () =>
       const timeout = failOnTimeout("did not receive MetadataContext from metadata app"); // fail if no metadataContext received
       const wrapper = wrapPromise();
 
-      listener = await appControlChannel.addContextListener("context-listener-triggered", async (context: MetadataContext) => {
+      listener = await appControlChannel.addContextListener(ControlContextType.ContextListenerTriggered, async (context: MetadataContext) => {
         implMetadata = context.implMetadata;
         wrapper.resolve();
         clearTimeout(timeout);

--- a/src/test/v2.0/advanced/fdc3.raiseIntent-Result.ts
+++ b/src/test/v2.0/advanced/fdc3.raiseIntent-Result.ts
@@ -1,7 +1,8 @@
 import { Listener } from "fdc3_2_0";
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
-import { RaiseIntentControl2_0, IntentResultType, IntentApp, ContextType, Intent } from "../support/intent-support-2.0";
+import { RaiseIntentControl2_0, IntentResultType, IntentApp, ContextType, Intent, ControlContextType } from "../support/intent-support-2.0";
 import { wait } from "../../../utils";
+import constants from "../../../constants";
 
 const control = new RaiseIntentControl2_0();
 
@@ -31,7 +32,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentVoidResult5secs = "(2.0-RaiseIntentVoidResult5secs) App A receives a void IntentResult after a 5 second delay";
     it(RaiseIntentVoidResult5secs, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext("aTestingIntent-listener-triggered", 8000);
+      let receiver = control.receiveContext(ControlContextType.aTestingIntentListenerTriggered, 8000);
       const intentResolution = await control.raiseIntent(Intent.aTestingIntent, ContextType.testContextX, undefined, 5000);
       control.validateIntentResolution(IntentApp.IntentAppA, intentResolution);
       let intentResultPromise = control.getIntentResult(intentResolution);
@@ -55,7 +56,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentContextResult5secs = "(2.0-RaiseIntentContextResult5secs) IntentResult resolves to testContextY instance after a 5 second delay";
     it(RaiseIntentContextResult5secs, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext("sharedTestingIntent1-listener-triggered", 8000);
+      let receiver = control.receiveContext(ControlContextType.sharedTestingIntent1ListenerTriggered, 8000);
       const intentResolution = await control.raiseIntent(Intent.sharedTestingIntent1, ContextType.testContextY, undefined, 5000);
       control.validateIntentResolution(IntentApp.IntentAppB, intentResolution);
       const intentResultPromise = control.getIntentResult(intentResolution);
@@ -70,7 +71,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentChannelResult = "(2.0-RaiseIntentChannelResult) IntentResult resolves to a Channel object";
     it(RaiseIntentChannelResult, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext(ContextType.testContextZ, 5000);
+      let receiver = control.receiveContext(ControlContextType.sharedTestingIntent2ResultSent, constants.WaitTime);
       const intentResolution = await control.raiseIntent(Intent.sharedTestingIntent2, ContextType.testContextY, {
         appId: IntentApp.IntentAppE,
       });
@@ -87,7 +88,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentPrivateChannelResult = "(2.0-RaiseIntentPrivateChannelResult) IntentResult resolves to a private Channel object";
     it(RaiseIntentPrivateChannelResult, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext(ContextType.testContextZ, 5000);
+      let receiver = control.receiveContext(ControlContextType.sharedTestingIntent2ResultSent, constants.WaitTime);
       const intentResolution = await control.raiseIntent(Intent.sharedTestingIntent2, ContextType.testContextY, {
         appId: IntentApp.IntentAppF,
       });
@@ -104,7 +105,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentVoidResult61secs = "(2.0-RaiseIntentVoidResult61secs) App A receives a void IntentResult after a 61 second delay";
     it(RaiseIntentVoidResult61secs, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext("aTestingIntent-listener-triggered", 64000);
+      let receiver = control.receiveContext(ControlContextType.aTestingIntentListenerTriggered, 64000);
       const intentResolution = await control.raiseIntent(Intent.aTestingIntent, ContextType.testContextX, undefined, 61000);
       control.validateIntentResolution(IntentApp.IntentAppA, intentResolution);
       let intentResultPromise = control.getIntentResult(intentResolution);
@@ -119,7 +120,7 @@ describe("fdc3.raiseIntent (Result)", () => {
     const RaiseIntentContextResult61secs = "(2.0-RaiseIntentContextResult61secs) IntentResult resolves to testContextY instance after a 61 second delay";
     it(RaiseIntentContextResult61secs, async () => {
       errorListener = await control.listenForError();
-      let receiver = control.receiveContext("sharedTestingIntent1-listener-triggered", 64000);
+      let receiver = control.receiveContext(ControlContextType.sharedTestingIntent1ListenerTriggered, 64000);
       const intentResolution = await control.raiseIntent(Intent.sharedTestingIntent1, ContextType.testContextY, undefined, 61000);
       control.validateIntentResolution(IntentApp.IntentAppB, intentResolution);
       let intentResultPromise = control.getIntentResult(intentResolution);

--- a/src/test/v2.0/advanced/fdc3.raiseIntent.ts
+++ b/src/test/v2.0/advanced/fdc3.raiseIntent.ts
@@ -1,6 +1,6 @@
 import { ChannelError, PrivateChannel, Listener } from "fdc3_2_0";
 import { assert, expect } from "chai";
-import { RaiseIntentControl2_0, IntentResultType, IntentApp, ContextType, Intent } from "../support/intent-support-2.0";
+import { RaiseIntentControl2_0, IntentResultType, IntentApp, ContextType, Intent, ControlContextType } from "../support/intent-support-2.0";
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
 
 const control = new RaiseIntentControl2_0();
@@ -24,7 +24,7 @@ export default () =>
     const RaiseIntentSingleResolve = "(2.0-RaiseIntentSingleResolve) Should start app intent-a when raising intent 'aTestingIntent1' with context 'testContextX'";
     it(RaiseIntentSingleResolve, async () => {
       errorListener = await control.listenForError();
-      const result = control.receiveContext("aTestingIntent-listener-triggered");
+      const result = control.receiveContext(ControlContextType.aTestingIntentListenerTriggered);
       const intentResolution = await control.raiseIntent(Intent.aTestingIntent, ContextType.testContextX);
       control.validateIntentResolution(IntentApp.IntentAppA, intentResolution);
       await result;
@@ -33,7 +33,7 @@ export default () =>
     const RaiseIntentTargetedAppResolve = "(2.0-RaiseIntentTargetedAppResolve) Should start app intent-b when raising intent 'sharedTestingIntent1' with context 'testContextX'";
     it(RaiseIntentTargetedAppResolve, async () => {
       errorListener = await control.listenForError();
-      const result = control.receiveContext("sharedTestingIntent1-listener-triggered");
+      const result = control.receiveContext(ControlContextType.sharedTestingIntent1ListenerTriggered);
       const intentResolution = await control.raiseIntent(Intent.sharedTestingIntent1, ContextType.testContextX, {
         appId: IntentApp.IntentAppB,
       });
@@ -45,8 +45,8 @@ export default () =>
     it(RaiseIntentTargetedInstanceResolveOpen, async () => {
       // add app control listeners
       errorListener = await control.listenForError();
-      const confirmAppOpened = control.receiveContext("intent-app-a-opened");
-      const result = control.receiveContext("aTestingIntent-listener-triggered");
+      const confirmAppOpened = control.receiveContext(ControlContextType.intentAppAOpened);
+      const result = control.receiveContext(ControlContextType.aTestingIntentListenerTriggered);
 
       const appIdentifier = await control.openIntentApp(IntentApp.IntentAppA);
       await confirmAppOpened;
@@ -62,8 +62,8 @@ export default () =>
     it(RaiseIntentTargetedInstanceResolveFindInstances, async () => {
       // add app control listeners
       errorListener = await control.listenForError();
-      const confirmAppOpened = control.receiveContext("intent-app-a-opened");
-      const result = control.receiveContext("aTestingIntent-listener-triggered");
+      const confirmAppOpened = control.receiveContext(ControlContextType.intentAppAOpened);
+      const result = control.receiveContext(ControlContextType.aTestingIntentListenerTriggered);
 
       const appIdentifier = await control.openIntentApp(IntentApp.IntentAppA);
       const instances = await control.findInstances(IntentApp.IntentAppA);
@@ -103,7 +103,7 @@ export default () =>
     const PrivateChannelsLifecycleEvents = "(2.0-PrivateChannelsLifecycleEvents) PrivateChannel lifecycle events are triggered when expected";
     it(PrivateChannelsLifecycleEvents, async () => {
       errorListener = await control.listenForError();
-      let onUnsubscribeReceiver = control.receiveContext("onUnsubscribeTriggered");
+      let onUnsubscribeReceiver = control.receiveContext(ControlContextType.onUnsubscribeTriggered);
       const intentResolution = await control.raiseIntent(Intent.kTestingIntent, ContextType.testContextX, {
         appId: IntentApp.IntentAppK,
       });
@@ -116,8 +116,8 @@ export default () =>
       let textContextXReceiver = control.receiveContext(ContextType.testContextX);
       control.privateChannelBroadcast(<PrivateChannel>result, ContextType.testContextX);
       await textContextXReceiver;
-      let onUnsubscribeReceiver2 = control.receiveContext("onUnsubscribeTriggered");
-      let onDisconnectReceiver = control.receiveContext("onDisconnectTriggered");
+      let onUnsubscribeReceiver2 = control.receiveContext(ControlContextType.onUnsubscribeTriggered);
+      let onDisconnectReceiver = control.receiveContext(ControlContextType.onDisconnectTriggered);
       let listener2 = await control.receiveContextStreamFromMockApp(<PrivateChannel>result, 6, 10);
       control.disconnectPrivateChannel(<PrivateChannel>result);
 

--- a/src/test/v2.0/support/intent-support-2.0.ts
+++ b/src/test/v2.0/support/intent-support-2.0.ts
@@ -12,7 +12,7 @@ export class RaiseIntentControl2_0 {
   async receiveContext(contextType: string, waitTime?: number): Promise<AppControlContext> {
     let timeout;
     const appControlChannel = await getOrCreateChannel(constants.ControlChannel);
-    const messageReceived = new Promise<Context>(async (resolve, reject) => {
+    return new Promise<Context>(async (resolve, reject) => {
       const listener = await appControlChannel.addContextListener(contextType, (context: AppControlContext) => {
         resolve(context);
         clearTimeout(timeout);
@@ -23,10 +23,8 @@ export class RaiseIntentControl2_0 {
       const { promise: sleepPromise, timeout: theTimeout } = sleep(waitTime ?? constants.WaitTime);
       timeout = theTimeout;
       await sleepPromise;
-      reject("No context received. Listener expected to receive context of type " + contextType + " from mock app");
+      reject(new Error("No context received. Listener expected to receive context of type " + contextType + " from mock app"));
     });
-
-    return messageReceived;
   }
 
   async openIntentApp(appId): Promise<AppIdentifier> {
@@ -221,6 +219,20 @@ export enum ContextType {
   testContextL = "testContextL",
   nonExistentContext = "nonExistentContext",
   privateChannelDetails = "privateChannelDetails",
+}
+
+export enum ControlContextType {
+  contextReceived = "context-received",
+  error = "error",
+  aTestingIntentListenerTriggered = "aTestingIntent-listener-triggered",
+  intentAppAOpened = "intent-app-a-opened",
+  sharedTestingIntent1ListenerTriggered = "sharedTestingIntent1-listener-triggered",
+  sharedTestingIntent2ResultSent = "sharedTestingIntent2-result-sent",
+  onUnsubscribeTriggered = "onUnsubscribeTriggered",
+  onDisconnectTriggered = "onDisconnectTriggered",
+  ContextListenerTriggered = "context-listener-triggered",
+  IntentListenerTriggered = "intent-listener-triggered",
+
 }
 
 export enum Intent {

--- a/src/test/v2.0/support/open-support-2.0.ts
+++ b/src/test/v2.0/support/open-support-2.0.ts
@@ -7,6 +7,7 @@ import { AppControlContext } from "../../../context-types";
 import { OpenControl } from "../../common/control/open-control";
 import { APIDocumentation2_0 } from "../apiDocuments-2.0";
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
+import { ControlContextType } from "./intent-support-2.0";
 
 declare let fdc3: DesktopAgent;
 const openDocs = "\r\nDocumentation: " + APIDocumentation2_0.open + "\r\nCause:";
@@ -58,7 +59,7 @@ export class OpenControl2_0 implements OpenControl<Context> {
   }
   addListenerAndFailIfReceived = async () => {
     const appControlChannel = await fdc3.getOrCreateChannel(constants.ControlChannel);
-    await appControlChannel.addContextListener("context-received", (context: AppControlContext) => {
+    await appControlChannel.addContextListener(ControlContextType.contextReceived, (context: AppControlContext) => {
       assert.fail(context.errorMessage);
     });
   };

--- a/src/test/v2.1/advanced/fdc3.open.ts
+++ b/src/test/v2.1/advanced/fdc3.open.ts
@@ -5,6 +5,7 @@ import { APIDocumentation2_1 } from "../apiDocuments-2.1";
 import { OpenControl2_1 } from "../support/open-support-2.1";
 import { DesktopAgent } from "fdc3_2_0";
 import { assert, expect } from "chai";
+import { ControlContextType } from "../../v2.0/support/intent-support-2.0";
 
 const openDocs = "\r\nDocumentation: " + APIDocumentation2_1 + "\r\nCause:";
 const control = new OpenControl2_1();
@@ -24,7 +25,7 @@ export default () =>
     //run v2.0-only open tests
     const AOpensBMalformedContext = `(AOpensBMalformedContext) App B listeners receive nothing when passing a malformed context`;
     it(AOpensBMalformedContext, async () => {
-      const receiver = control.contextReceiver("context-received");
+      const receiver = control.contextReceiver(ControlContextType.contextReceived);
       await control.openMockApp(openApp.f.name);
       await receiver;
       await control.closeMockApp(AOpensBMalformedContext);


### PR DESCRIPTION
The intent tests which test channel results contain a race condition that often fails in a local run and always fails on a lower-performance CI machine. There are also a number of minor issues the app definitions that should be fixed (but don't cause failures, but might in some implementations if they require the appD record to be accurate) and excessive use of magic strings rather than string constants.

This PR: 
- Corrects the Intent Channel result tests, 
- Ensures Errors are thrown on timeouts rather than strings,
- Makes sure the intent tests use constants for control message types, rather than magic strings.
- Removes` bTestingIntent` from the Intent B app's appD definition as it is not used and no listener is added for it by the v2.0 test app.
- Adds `ConformanceListener` to Conformance1's declared intents as it adds a listener to it
- Removing `aTestingIntent` listener from metadata app as its not used and was likely a copy/paste error

intent-e and intent-f are the main files to review.

Tests re-run against Finsemble which passes all (previously failing the 2 intent channel tests, which had the race conditions):

![image](https://github.com/finos/FDC3-conformance-framework/assets/1701764/49df9e4e-c54f-4501-94bb-ec970d0ddecc)
