### PR TITLE
Bugfixes: FDC3 2.0 Conformance OSFF 2024

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ const constants = {
   ShortWait: 1000,
   Fdc3Timeout: 500, // The amount of time to wait for the FDC3Ready event during initialisation
   TestTimeout: 20000, // Tests that take longer than this (in milliseconds) will fail
+  ManualTimeout: 100000, // Manual tests that take longer than this (in milliseconds) will fail
   WaitTime: 5000, // The amount of time to wait for mock apps to finish processing
   WindowCloseWaitTime: 1000, // The amount of time to allow for clean-up of closed windows
   NoListenerTimeout: 120000, // the amount of time to allow for a DA to timeout waiting on a context or intent listener

--- a/src/test/v2.0/advanced/fdc3.findIntent.ts
+++ b/src/test/v2.0/advanced/fdc3.findIntent.ts
@@ -41,12 +41,12 @@ export default () =>
 
     it("(2.0-FindIntentAppDMultiple1) Should find intent 'sharedTestingIntent2' belonging to multiple apps (intent-a & intent-b)", async () => {
       const appIntent = await fdc3.findIntent(Intent.sharedTestingIntent2);
-      validateAppIntent(appIntent, 6, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent" }, IntentApp.IntentAppD);
+      validateAppIntent(appIntent, 6, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent 2" }, IntentApp.IntentAppD);
     });
 
     it("(IntentAppDMultiple2) Should find intent 'sharedTestingIntent2' belonging to multiple apps (intent-a & intent-b) filtered by specific context 'testContextY'", async () => {
       const appIntent = await fdc3.findIntent(Intent.sharedTestingIntent2, { type: ContextType.testContextY });
-      validateAppIntent(appIntent, 5, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent" }, IntentApp.IntentAppE);
+      validateAppIntent(appIntent, 5, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent 2" }, IntentApp.IntentAppE);
     });
 
     it("(2.0-FindIntentAppDByResultSingle) Should find intent 'cTestingIntent' belonging only to app intent-c with context 'testContextX' and result type 'testContextZ'", async () => {
@@ -61,17 +61,17 @@ export default () =>
 
     it("(2.0-FindIntentAppDByResultMultiple) Should find intent 'sharedTestingIntent1' belonging only to app intent-b with context 'testContextX' and result type 'testContextY'", async () => {
       const appIntent = await fdc3.findIntent(Intent.sharedTestingIntent1, { type: ContextType.testContextX }, ContextType.testContextY);
-      validateAppIntent(appIntent, 1, { name: Intent.sharedTestingIntent1, displayName: "Shared Testing Intent" }, IntentApp.IntentAppB);
+      validateAppIntent(appIntent, 1, { name: Intent.sharedTestingIntent1, displayName: "Shared Testing Intent 1" }, IntentApp.IntentAppB);
     });
 
     it("(2.0-FindIntentAppDByResultChannel1) Should find intent 'sharedTestingIntent2' belonging only to apps intent-e and itent-f with context 'testContextY' and result type 'channel", async () => {
       const appIntent = await fdc3.findIntent(Intent.sharedTestingIntent2, { type: ContextType.testContextY }, "channel");
-      validateAppIntent(appIntent, 2, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent" }, IntentApp.IntentAppE);
+      validateAppIntent(appIntent, 2, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent 2" }, IntentApp.IntentAppE);
     });
 
     it("(2.0-FindIntentAppDByResultChannel2) Should find intent 'sharedTestingIntent2' belonging only to app intent-c with context 'testContextY' and result type 'channel<testContextZ>'", async () => {
       const appIntent = await fdc3.findIntent(Intent.sharedTestingIntent2, { type: ContextType.testContextY }, "channel<testContextZ>");
-      validateAppIntent(appIntent, 1, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent" }, IntentApp.IntentAppF);
+      validateAppIntent(appIntent, 1, { name: Intent.sharedTestingIntent2, displayName: "Shared Testing Intent 2" }, IntentApp.IntentAppF);
     });
   });
 

--- a/src/test/v2.0/manual/fdc3.manual.ts
+++ b/src/test/v2.0/manual/fdc3.manual.ts
@@ -1,10 +1,9 @@
-import { ResolveError, DesktopAgent } from "fdc3_2_0";
+import { DesktopAgent } from "fdc3_2_0";
 
 import { closeMockAppWindow } from "../fdc3-2_0-utils";
 import { assert, expect } from "chai";
 import { APIDocumentation2_0 } from "../apiDocuments-2.0";
 import { ContextType, IntentApp, Intent, RaiseIntentControl2_0 } from "../support/intent-support-2.0";
-import constants from "../../../constants";
 import { wait } from "../../../utils";
 
 
@@ -19,81 +18,81 @@ declare let fdc3: DesktopAgent;
  */
 
 export let fdc3ResolveAmbiguousIntentTarget_2_0 = () => describe("ResolveAmbiguousIntentTarget_2.0", () => {
-    after(async function after() {
-        await closeMockAppWindow(this.currentTest.title);
-    });
-    const ResolveAmbiguousIntentTarget = "(ResolveAmbiguousIntentTarget) Should be able to raise intent using Intent and Context and manually select an app out of 'E','F','G','H' and 'I'";
-    it(ResolveAmbiguousIntentTarget, async () => {
-      try {
-        const context = {
-            type: ContextType.testContextY,
-          };
-        await fdc3.raiseIntent(Intent.sharedTestingIntent2, context);
-      } catch (ex) {
-        assert.fail(raiseIntentDocs + (ex.message ?? ex));
-      }
-    });
+  after(async function after() {
+    await closeMockAppWindow(this.currentTest.title);
   });
+  const ResolveAmbiguousIntentTarget = "(ResolveAmbiguousIntentTarget) Should be able to raise intent using Intent and Context and manually select an app out of 'E','F','G','H' and 'I'";
+  it(ResolveAmbiguousIntentTarget, async () => {
+    try {
+      const context = {
+        type: ContextType.testContextY,
+      };
+      await fdc3.raiseIntent(Intent.sharedTestingIntent2, context);
+    } catch (ex) {
+      assert.fail(raiseIntentDocs + (ex.message ?? ex));
+    }
+  });
+});
 
-  export let fdc3ResolveAmbiguousContextTarget_2_0 = () => describe("ResolveAmbiguousContextTarget_2.0", () => {
-    after(async function after() {
-        await closeMockAppWindow(this.currentTest.title);
-    });
-    const ResolveAmbiguousIntentTarget = "(ResolveAmbiguousContextTarget) Should be able to raise intent using ContextY and manually select an app out of 'E','F','G','H' and 'I'";
-    it(ResolveAmbiguousIntentTarget, async () => {
-      try {
-        const context = {
-            type: ContextType.testContextY,
-          };
-        await fdc3.raiseIntentForContext(context);
-      } catch (ex) {
-        assert.fail(raiseIntentDocs + (ex.message ?? ex));
-      }
-    });
+export let fdc3ResolveAmbiguousContextTarget_2_0 = () => describe("ResolveAmbiguousContextTarget_2.0", () => {
+  after(async function after() {
+    await closeMockAppWindow(this.currentTest.title);
   });
+  const ResolveAmbiguousIntentTarget = "(ResolveAmbiguousContextTarget) Should be able to raise intent using ContextY and manually select an app out of 'E','F','G','H' and 'I'";
+  it(ResolveAmbiguousIntentTarget, async () => {
+    try {
+      const context = {
+        type: ContextType.testContextY,
+      };
+      await fdc3.raiseIntentForContext(context);
+    } catch (ex) {
+      assert.fail(raiseIntentDocs + (ex.message ?? ex));
+    }
+  });
+});
 
-  export let fdc3ResolveAmbiguousIntentTargetMultiInstance_2_0 = () => describe("ResolveAmbiguousIntentTargetMultiInstance_2.0", () => {
-    after(async function after() {
-        await closeMockAppWindow(this.currentTest.title);
-    });
-    const ResolveAmbiguousIntentTargetMultiInstance = "(ResolveAmbiguousIntentTargetMultiInstance) Open 2 instances of App E and AppF respectively and then should be able to raise intent using Intent and Context and manually select an app out of 'E','F','G','H' and 'I'";
-    it(ResolveAmbiguousIntentTargetMultiInstance, async () => {
-      try {
-        const context = {
-            type: ContextType.testContextY,
-          };
-        await control.openIntentApp(IntentApp.IntentAppE);
-        await control.openIntentApp(IntentApp.IntentAppE);
-        await control.openIntentApp(IntentApp.IntentAppF);
-        await control.openIntentApp(IntentApp.IntentAppF);
-        await wait(100);
-        
-        await fdc3.raiseIntent(Intent.sharedTestingIntent2, context);
-      } catch (ex) {
-        assert.fail(raiseIntentDocs + (ex.message ?? ex));
-      }
-    });
+export let fdc3ResolveAmbiguousIntentTargetMultiInstance_2_0 = () => describe("ResolveAmbiguousIntentTargetMultiInstance_2.0", () => {
+  after(async function after() {
+    await closeMockAppWindow(this.currentTest.title);
   });
+  const ResolveAmbiguousIntentTargetMultiInstance = "(ResolveAmbiguousIntentTargetMultiInstance) Open 2 instances of App E and AppF respectively and then should be able to raise intent using Intent and Context and manually select an app out of 'E','F','G','H' and 'I'";
+  it(ResolveAmbiguousIntentTargetMultiInstance, async () => {
+    try {
+      const context = {
+        type: ContextType.testContextY,
+      };
+      await control.openIntentApp(IntentApp.IntentAppE);
+      await control.openIntentApp(IntentApp.IntentAppE);
+      await control.openIntentApp(IntentApp.IntentAppF);
+      await control.openIntentApp(IntentApp.IntentAppF);
+      await wait(100);
 
-  export let fdc3ResolveAmbiguousContextTargetMultiInstance_2_0 = () => describe("ResolveAmbiguousContextTargetMultiInstance_2.0", () => {
-    after(async function after() {
-        await closeMockAppWindow(this.currentTest.title);
-    });
-    const ResolveAmbiguousContextTargetMultiInstance = "(ResolveAmbiguousContextTargetMultiInstance) Open 2 instances of App E and AppF respectively and then should be able to raise intent using Context and manually select an app out of 'E','F','G','H' and 'I'";
-    it(ResolveAmbiguousContextTargetMultiInstance, async () => {
-      try {
-        const context = {
-            type: ContextType.testContextY,
-          };
-        await control.openIntentApp(IntentApp.IntentAppE);
-        await control.openIntentApp(IntentApp.IntentAppE);
-        await control.openIntentApp(IntentApp.IntentAppF);
-        await control.openIntentApp(IntentApp.IntentAppF);
-        await wait(100);
-        
-        await fdc3.raiseIntentForContext(context);
-      } catch (ex) {
-        assert.fail(raiseIntentDocs + (ex.message ?? ex));
-      }
-    });
+      await fdc3.raiseIntent(Intent.sharedTestingIntent2, context);
+    } catch (ex) {
+      assert.fail(raiseIntentDocs + (ex.message ?? ex));
+    }
   });
+});
+
+export let fdc3ResolveAmbiguousContextTargetMultiInstance_2_0 = () => describe("ResolveAmbiguousContextTargetMultiInstance_2.0", () => {
+  after(async function after() {
+    await closeMockAppWindow(this.currentTest.title);
+  });
+  const ResolveAmbiguousContextTargetMultiInstance = "(ResolveAmbiguousContextTargetMultiInstance) Open 2 instances of App E and AppF respectively and then should be able to raise intent using Context and manually select an app out of 'E','F','G','H' and 'I'";
+  it(ResolveAmbiguousContextTargetMultiInstance, async () => {
+    try {
+      const context = {
+        type: ContextType.testContextY,
+      };
+      await control.openIntentApp(IntentApp.IntentAppE);
+      await control.openIntentApp(IntentApp.IntentAppE);
+      await control.openIntentApp(IntentApp.IntentAppF);
+      await control.openIntentApp(IntentApp.IntentAppF);
+      await wait(100);
+
+      await fdc3.raiseIntentForContext(context);
+    } catch (ex) {
+      assert.fail(raiseIntentDocs + (ex.message ?? ex));
+    }
+  });
+});

--- a/src/test/v2.0/testSuite.ts
+++ b/src/test/v2.0/testSuite.ts
@@ -99,7 +99,7 @@ export const executeTestsInBrowser = (pack: string) => {
  */
 export const executeManualTestsInBrowser = (pack: string) => {
   console.log('Pack',pack);
-  (mocha as any).timeout(constants.TestTimeout);
+  (mocha as any).timeout(constants.ManualTimeout);
   const suite = allManualTests[pack];
   console.log('************ found suite******', suite)
   suite.forEach((s) => s());


### PR DESCRIPTION
1. v2.0/advanced/fdc3.findIntent.ts: Fixed the displayName for Intent.sharedTestingIntent2 and Intent.sharedTestingIntent1 to 'Shared Testing Intent 2' and 'Shared Testing Intent 1', respectively.

2. v2.0/advanced/fdc3.raiseIntent.ts: Suggesting adding a brief delay of ~300ms at line 118 after the context listeners are added, and before broadcasting the context to private channel, to ensure the Desktop Agent has sufficient time to initialize everything properly.

3. Manual Tests: The TestTimeout of 20,000ms seemed insufficient for fdc3ResolveAmbiguousContextTargetMultiInstance_2_0 and fdc3ResolveAmbiguousIntentTargetMultiInstance_2_0. These tests open four applications, then trigger a UI resolver app, which waits for user input before resolving. Given the dependency on user action, suggesting that the timeout should be extended.